### PR TITLE
Extend the client

### DIFF
--- a/internal/client/converterv1.go
+++ b/internal/client/converterv1.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	apiV1Client "github.com/qase-tms/qase-go/qase-api-client"
+	models "github.com/qase-tms/qasectl/internal/models/import"
+	"os"
+)
+
+func (c *ClientV1) convertResultToApiModel(ctx context.Context, projectCode string, result models.Result) apiV1Client.ResultCreate {
+	startTime := int32(result.Execution.StartTime.Unix())
+	endTime := result.Execution.EndTime.Unix()
+	duration := result.Execution.EndTime.Sub(*result.Execution.StartTime).Microseconds()
+	defect := false
+	model := apiV1Client.ResultCreate{
+		CaseId:      result.TestOpsID,
+		Status:      result.Execution.Status,
+		StartTime:   *apiV1Client.NewNullableInt32(&startTime),
+		Time:        *apiV1Client.NewNullableInt64(&endTime),
+		TimeMs:      *apiV1Client.NewNullableInt64(&duration),
+		Comment:     *apiV1Client.NewNullableString(result.Message),
+		Defect:      *apiV1Client.NewNullableBool(&defect),
+		Stacktrace:  *apiV1Client.NewNullableString(result.Execution.StackTrace),
+		Param:       result.Params,
+		Steps:       c.convertStepToApiModel(ctx, projectCode, result.Steps),
+		Attachments: c.convertAttachments(ctx, projectCode, result.Attachments),
+	}
+
+	if result.TestOpsID == nil {
+		caseModel := apiV1Client.ResultCreateCase{
+			Title: &result.Title,
+		}
+
+		if v, ok := result.Fields["description"]; ok {
+			caseModel.Description = *apiV1Client.NewNullableString(&v)
+		}
+
+		if v, ok := result.Fields["severity"]; ok {
+			caseModel.Severity = &v
+		}
+
+		if v, ok := result.Fields["priority"]; ok {
+			caseModel.Priority = &v
+		}
+
+		if v, ok := result.Fields["layer"]; ok {
+			caseModel.Layer = &v
+		}
+
+		if v, ok := result.Fields["preconditions"]; ok {
+			caseModel.Preconditions = *apiV1Client.NewNullableString(&v)
+		}
+
+		if v, ok := result.Fields["postconditions"]; ok {
+			caseModel.Postconditions = *apiV1Client.NewNullableString(&v)
+		}
+
+		if result.Relations.Suite.Data != nil {
+			var suite string
+
+			for _, s := range result.Relations.Suite.Data {
+				suite += s.Title + "\t"
+			}
+
+			caseModel.SuiteTitle = *apiV1Client.NewNullableString(&suite)
+		}
+
+		model.Case = &caseModel
+	}
+
+	return model
+}
+
+func (c *ClientV1) convertAttachments(ctx context.Context, projectCode string, attachments []models.Attachment) []string {
+	results := make([]string, 0, len(attachments))
+
+	for _, attachment := range attachments {
+		// TODO: convert attachment from content to file
+		file, err := os.Open(*attachment.FilePath)
+		if err != nil {
+			fmt.Println("failed to open file: %w", err)
+			continue
+		}
+
+		hash, err := c.uploadAttachment(ctx, projectCode, []*os.File{file})
+		if err != nil {
+			fmt.Println("failed to upload attachment: %w", err)
+			continue
+		}
+
+		results = append(results, hash)
+	}
+
+	return results
+}
+
+func (c *ClientV1) convertStepToApiModel(ctx context.Context, projectCode string, steps []models.Step) []apiV1Client.TestStepResultCreate {
+	stepModels := make([]apiV1Client.TestStepResultCreate, 0, len(steps))
+
+	for _, step := range steps {
+		stepModel := apiV1Client.TestStepResultCreate{
+			Status:      step.Execution.Status,
+			Comment:     *apiV1Client.NewNullableString(&step.Execution.Comment),
+			Attachments: c.convertAttachments(ctx, projectCode, step.Execution.Attachments),
+			Steps:       c.convertStepToMaps(ctx, projectCode, step.Steps),
+			Action:      &step.Data.Action,
+		}
+
+		stepModels = append(stepModels, stepModel)
+	}
+
+	return stepModels
+}
+
+func (c *ClientV1) convertStepToMaps(ctx context.Context, projectCode string, steps []models.Step) []map[string]interface{} {
+	stepModels := make([]map[string]interface{}, 0, len(steps))
+
+	for _, step := range steps {
+
+		stepModel := map[string]interface{}{
+			"Status":      step.Execution.Status,
+			"Comment":     *apiV1Client.NewNullableString(&step.Execution.Comment),
+			"Attachments": c.convertAttachments(ctx, projectCode, step.Execution.Attachments),
+			"Steps":       c.convertStepToMaps(ctx, projectCode, step.Steps),
+			"Action":      step.Data.Action,
+		}
+
+		stepModels = append(stepModels, stepModel)
+	}
+
+	return stepModels
+}

--- a/internal/models/import/attachment.go
+++ b/internal/models/import/attachment.go
@@ -1,0 +1,9 @@
+package _import
+
+type Attachment struct {
+	ID          *int64
+	Name        string
+	FilePath    *string
+	ContentType string
+	Content     *[]byte
+}

--- a/internal/models/import/data.go
+++ b/internal/models/import/data.go
@@ -1,0 +1,8 @@
+package _import
+
+type Data struct {
+	Action         string
+	ExceptedResult *string
+	InputData      *string
+	Attachments    []Attachment
+}

--- a/internal/models/import/execution.go
+++ b/internal/models/import/execution.go
@@ -1,0 +1,12 @@
+package _import
+
+import "time"
+
+type Execution struct {
+	StartTime  *time.Time
+	EndTime    *time.Time
+	Status     string
+	Duration   time.Duration
+	StackTrace *string
+	Thread     *string
+}

--- a/internal/models/import/relation.go
+++ b/internal/models/import/relation.go
@@ -1,0 +1,5 @@
+package _import
+
+type Relation struct {
+	Suite Suite
+}

--- a/internal/models/import/result.go
+++ b/internal/models/import/result.go
@@ -1,0 +1,22 @@
+package _import
+
+import "time"
+
+type Result struct {
+	ID          *int64
+	Title       string
+	Signature   *string
+	TestOpsID   *int64
+	Execution   Execution
+	Fields      map[string]string
+	Attachments []Attachment
+	Steps       []Step
+	StepType    string
+	Params      map[string]string
+	Relations   Relation
+	Muted       bool
+	Message     *string
+	StartTime   *time.Time
+	EndTime     *time.Time
+	Duration    *time.Duration
+}

--- a/internal/models/import/step.go
+++ b/internal/models/import/step.go
@@ -1,0 +1,7 @@
+package _import
+
+type Step struct {
+	Data      Data
+	Execution StepExecution
+	Steps     []Step
+}

--- a/internal/models/import/stepexecution.go
+++ b/internal/models/import/stepexecution.go
@@ -1,0 +1,12 @@
+package _import
+
+import "time"
+
+type StepExecution struct {
+	StartTime   *time.Time
+	EndTime     *time.Time
+	Status      string
+	Duration    *time.Duration
+	Comment     string
+	Attachments []Attachment
+}

--- a/internal/models/import/suite.go
+++ b/internal/models/import/suite.go
@@ -1,0 +1,5 @@
+package _import
+
+type Suite struct {
+	Data []SuiteData
+}

--- a/internal/models/import/suitedata.go
+++ b/internal/models/import/suitedata.go
@@ -1,0 +1,6 @@
+package _import
+
+type SuiteData struct {
+	Title    string
+	PublicID *int64
+}

--- a/internal/parsers/junit/junit.go
+++ b/internal/parsers/junit/junit.go
@@ -1,0 +1,157 @@
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	models "github.com/qase-tms/qasectl/internal/models/import"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Parser is a parser for Junit XML files
+type Parser struct {
+	path string
+}
+
+// NewParser creates a new Parser
+func NewParser(path string) *Parser {
+	return &Parser{
+		path: path,
+	}
+}
+
+// Parse parses the Junit XML file and returns the results
+func (p *Parser) Parse() ([]models.Result, error) {
+	var results []models.Result
+
+	fileInfo, err := os.Stat(p.path)
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo.IsDir() {
+		err := filepath.Walk(p.path, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				result, err := p.parseFile(path)
+				if err != nil {
+					return err
+				}
+				results = append(results, result...)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		result, err := p.parseFile(p.path)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result...)
+	}
+
+	return results, nil
+}
+
+// parseFile parses a single Junit XML file
+func (p *Parser) parseFile(path string) ([]models.Result, error) {
+	xmlFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := xmlFile.Close()
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	byteValue, _ := io.ReadAll(xmlFile)
+
+	var testSuites TestSuites
+	err = xml.Unmarshal(byteValue, &testSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertTestSuites(testSuites), nil
+}
+
+// convertTestSuites converts a TestSuites to Results
+func convertTestSuites(testSuites TestSuites) []models.Result {
+	results := make([]models.Result, 0)
+
+	for _, testSuite := range testSuites.TestSuites {
+		for _, testCase := range testSuite.TestCases {
+			relation := models.Relation{
+				Suite: models.Suite{
+					Data: []models.SuiteData{
+						{
+							Title: testSuites.Name,
+						},
+						{
+							Title: testSuite.Name,
+						},
+					},
+				},
+			}
+
+			signature := fmt.Sprintf("%s::%s::%s::%s", testSuites.Name, testSuite.Name, testCase.ClassName, testCase.Name)
+
+			status := "passed"
+			var stackTrace *string
+			var message *string
+
+			if testCase.Failure != nil {
+				status = "failed"
+				stackTrace = &testCase.Failure.Body
+				message = &testCase.Failure.Message
+			}
+
+			if testCase.Error != nil {
+				status = "invalid"
+				stackTrace = &testCase.Error.Body
+				message = &testCase.Error.Message
+			}
+
+			if testCase.Skipped != nil {
+				status = "skipped"
+				message = &testCase.Skipped.Message
+			}
+
+			fields := make(map[string]string)
+
+			for k := range testCase.Properties.Property {
+				fields[testCase.Properties.Property[k].Name] = testCase.Properties.Property[k].Value
+			}
+
+			result := models.Result{
+				Title:     testCase.Name,
+				Signature: &signature,
+				Relations: relation,
+				Execution: models.Execution{
+					Duration:   time.Duration(testCase.Time),
+					Status:     status,
+					StackTrace: stackTrace,
+				},
+				Attachments: make([]models.Attachment, 0),
+				Steps:       make([]models.Step, 0),
+				StepType:    "text",
+				Params:      make(map[string]string),
+				Muted:       false,
+				Fields:      fields,
+				Message:     message,
+			}
+			results = append(results, result)
+		}
+	}
+
+	return results
+}

--- a/internal/parsers/junit/models.go
+++ b/internal/parsers/junit/models.go
@@ -1,0 +1,76 @@
+package junit
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type Properties struct {
+	Property []Property `xml:"property"`
+}
+
+type TestCase struct {
+	Name       string     `xml:"name,attr"`
+	ClassName  string     `xml:"classname,attr"`
+	Assertions int        `xml:"assertions,attr"`
+	Time       float64    `xml:"time,attr"`
+	File       string     `xml:"file,attr"`
+	Line       int        `xml:"line,attr"`
+	Skipped    *Skipped   `xml:"skipped"`
+	Failure    *Failure   `xml:"failure"`
+	Error      *Error     `xml:"error"`
+	SystemOut  string     `xml:"system-out"`
+	SystemErr  string     `xml:"system-err"`
+	Properties Properties `xml:"properties"`
+}
+
+type Skipped struct {
+	Message string `xml:"message,attr"`
+}
+
+type Failure struct {
+	Message string `xml:"message,attr"`
+	Body    string `xml:",chardata"`
+	Type    string `xml:"type,attr"`
+}
+
+type Error struct {
+	Message string `xml:"message,attr"`
+	Body    string `xml:",chardata"`
+	Type    string `xml:"type,attr"`
+}
+
+type TestSuite struct {
+	XMLName    xml.Name   `xml:"testsuite"`
+	Name       string     `xml:"name,attr"`
+	Tests      int        `xml:"tests,attr"`
+	Failures   int        `xml:"failures,attr"`
+	Errors     int        `xml:"errors,attr"`
+	Skipped    int        `xml:"skipped,attr"`
+	Assertions int        `xml:"assertions,attr"`
+	Time       float64    `xml:"time,attr"`
+	Timestamp  time.Time  `xml:"timestamp,attr"`
+	File       string     `xml:"file,attr"`
+	Properties Properties `xml:"properties"`
+	SystemOut  string     `xml:"system-out"`
+	SystemErr  string     `xml:"system-err"`
+	TestCases  []TestCase `xml:"testcase"`
+}
+
+type TestSuites struct {
+	XMLName    xml.Name    `xml:"testsuites"`
+	Name       string      `xml:"name,attr"`
+	Tests      int         `xml:"tests,attr"`
+	Failures   int         `xml:"failures,attr"`
+	Errors     int         `xml:"errors,attr"`
+	Skipped    int         `xml:"skipped,attr"`
+	Assertions int         `xml:"assertions,attr"`
+	Time       float64     `xml:"time,attr"`
+	Timestamp  time.Time   `xml:"timestamp,attr"`
+	TestSuites []TestSuite `xml:"testsuite"`
+}

--- a/internal/service/import/import.go
+++ b/internal/service/import/import.go
@@ -1,0 +1,20 @@
+package _import
+
+import "context"
+import (
+	models "github.com/qase-tms/qasectl/internal/models/import"
+)
+
+type client interface {
+	UploadData(ctx context.Context, project string, runID int64, results []models.Result) error
+}
+
+// Service is a service for importing data
+type Service struct {
+	client *client
+}
+
+// NewService creates a new service
+func NewService(client *client) *Service {
+	return &Service{client: client}
+}


### PR DESCRIPTION
Added result models
--
These models describe the test result and will be used in internal logic

---

Extend the client
--
- added `UploadData` method to the client which uploads test results to the Qase.
- added a converter which converts internal models to APi models
- added base for import service

---

Added Junit XML parser
--
Added Junit XML parser which parses and converts Junit XML test result to internal models
