### PR TITLE
Added uploading of results in batch

### DIFF
--- a/cmd/testops/result/upload/upload.go
+++ b/cmd/testops/result/upload/upload.go
@@ -30,6 +30,7 @@ func Command() *cobra.Command {
 		title       string
 		description string
 		steps       string
+		batch       int64
 	)
 
 	cmd := &cobra.Command{
@@ -80,20 +81,12 @@ func Command() *cobra.Command {
 
 			s := result.NewService(c, p)
 
-			err := s.Import(cmd.Context(), project, runID)
-			if err != nil {
-				return err
-			}
-
-			if isTestRunCreated {
-				rs := run.NewService(c)
-
-				err := rs.CompleteRun(cmd.Context(), project, runID)
-				if err != nil {
-					return err
-				}
-
-				logger.Debug("Test run completed successfully", slog.Int64("id", runID))
+			param := result.UploadParams{
+				RunID:       runID,
+				Title:       title,
+				Description: &description,
+				Batch:       batch,
+				Project:     project,
 			}
 
 			logger.Info("Results uploaded successfully")
@@ -121,6 +114,7 @@ func Command() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive(runIDFlag, titleFlag)
 
 	cmd.Flags().StringVar(&steps, "steps", "", "Steps show mode in XCTest. Allowed values: all, user")
+	cmd.Flags().Int64VarP(&batch, "batch", "b", 200, "Batch size for uploading results")
 
 	return cmd
 }

--- a/cmd/testops/result/upload/upload.go
+++ b/cmd/testops/result/upload/upload.go
@@ -7,7 +7,6 @@ import (
 	"github.com/qase-tms/qasectl/internal/parsers/junit"
 	"github.com/qase-tms/qasectl/internal/parsers/xctest"
 	"github.com/qase-tms/qasectl/internal/service/result"
-	"github.com/qase-tms/qasectl/internal/service/run"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"log/slog"
@@ -64,21 +63,6 @@ func Command() *cobra.Command {
 			}
 
 			c := client.NewClientV1(token)
-			isTestRunCreated := false
-			if runID == 0 {
-				rs := run.NewService(c)
-
-				id, err := rs.CreateRun(cmd.Context(), project, title, &description)
-				if err != nil {
-					return err
-				}
-
-				runID = id
-				isTestRunCreated = true
-
-				logger.Debug("Test run created successfully", slog.String("title", title), slog.Int64("id", runID))
-			}
-
 			s := result.NewService(c, p)
 
 			param := result.UploadParams{
@@ -88,6 +72,8 @@ func Command() *cobra.Command {
 				Batch:       batch,
 				Project:     project,
 			}
+
+			s.Upload(cmd.Context(), param)
 
 			logger.Info("Results uploaded successfully")
 

--- a/internal/service/result/models.go
+++ b/internal/service/result/models.go
@@ -1,0 +1,9 @@
+package result
+
+type UploadParams struct {
+	RunID       int64
+	Title       string
+	Description *string
+	Batch       int64
+	Project     string
+}

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -3,10 +3,13 @@ package result
 import (
 	"context"
 	models "github.com/qase-tms/qasectl/internal/models/result"
+	"log/slog"
 )
 
 type client interface {
 	UploadData(ctx context.Context, project string, runID int64, results []models.Result) error
+	CreateRun(ctx context.Context, projectCode, title string, description *string) (int64, error)
+	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
 type Parser interface {


### PR DESCRIPTION
Added uploading of results in batch
--
- add new parameter `--batch` or `-b`. Default value is 200.
- improve logs in the result service

---

Improved logs in the client

---

Refactored result service.
--
Moved main logic from the command to the service.