### PR TITLE
run: add support environment

### DIFF
--- a/cmd/testops/result/upload/upload.go
+++ b/cmd/testops/result/upload/upload.go
@@ -9,6 +9,7 @@ import (
 	"github.com/qase-tms/qasectl/internal/parsers/qase"
 	"github.com/qase-tms/qasectl/internal/parsers/xctest"
 	"github.com/qase-tms/qasectl/internal/service/result"
+	"github.com/qase-tms/qasectl/internal/service/run"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"log/slog"
@@ -65,12 +66,13 @@ func Command() *cobra.Command {
 			}
 
 			c := client.NewClientV1(token)
-			s := result.NewService(c, p)
+			rs := run.NewService(c)
+			s := result.NewService(c, p, rs)
 
 			param := result.UploadParams{
 				RunID:       runID,
 				Title:       title,
-				Description: &description,
+				Description: description,
 				Batch:       batch,
 				Project:     project,
 			}

--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -12,6 +12,7 @@ import (
 const (
 	titleFlag       = "title"
 	descriptionFlag = "description"
+	environmentFlag = "environment"
 )
 
 // Command returns a new cobra command for create runs
@@ -19,12 +20,13 @@ func Command() *cobra.Command {
 	var (
 		title       string
 		description string
+		environment string
 	)
 
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a new test run",
-		Example: "qli run create --title 'My test run' --description 'This is a test run' --project 'PRJ' --token 'TOKEN'",
+		Example: "qli run create --title 'My test run' --description 'This is a test run' --environment local --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token := viper.GetString(flags.TokenFlag)
 			project := viper.GetString(flags.ProjectFlag)
@@ -32,7 +34,7 @@ func Command() *cobra.Command {
 			c := client.NewClientV1(token)
 			s := run.NewService(c)
 
-			id, err := s.CreateRun(cmd.Context(), project, title, &description)
+			id, err := s.CreateRun(cmd.Context(), project, title, description, environment)
 			if err != nil {
 				return err
 			}
@@ -49,6 +51,7 @@ func Command() *cobra.Command {
 		fmt.Println(err)
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the test run")
+	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "environment of the test run")
 
 	return cmd
 }

--- a/internal/models/run/environment.go
+++ b/internal/models/run/environment.go
@@ -1,0 +1,7 @@
+package run
+
+type Environment struct {
+	Title string `json:"title"`
+	ID    int64  `json:"id"`
+	Slug  string `json:"slug"`
+}

--- a/internal/service/result/models.go
+++ b/internal/service/result/models.go
@@ -3,7 +3,7 @@ package result
 type UploadParams struct {
 	RunID       int64
 	Title       string
-	Description *string
+	Description string
 	Batch       int64
 	Project     string
 }

--- a/internal/service/run/run.go
+++ b/internal/service/run/run.go
@@ -1,10 +1,15 @@
 package run
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"github.com/qase-tms/qasectl/internal/models/run"
+)
 
 // client is a client for run
 type client interface {
-	CreateRun(ctx context.Context, projectCode, title string, description *string) (int64, error)
+	GetEnvironments(ctx context.Context, projectCode string) ([]run.Environment, error)
+	CreateRun(ctx context.Context, projectCode, title string, description string, envID int64) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
@@ -19,8 +24,21 @@ func NewService(client client) *Service {
 }
 
 // CreateRun creates a new run
-func (s *Service) CreateRun(ctx context.Context, projectCode, title string, description *string) (int64, error) {
-	return s.client.CreateRun(ctx, projectCode, title, description)
+func (s *Service) CreateRun(ctx context.Context, p, t string, d, e string) (int64, error) {
+	var envID int64 = 0
+	if e != "" {
+		es, err := s.client.GetEnvironments(ctx, p)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get environments: %w", err)
+		}
+		for _, env := range es {
+			if env.Slug == e {
+				envID = env.ID
+			}
+		}
+	}
+
+	return s.client.CreateRun(ctx, p, t, d, envID)
 }
 
 // CompleteRun completes a run


### PR DESCRIPTION
clientv1: add get environment method and change signature of create test run method

---

run: add support environment
--
- add a new flag `environment`
- update internal logic of the run service

---

upload: update internal logic
--
- use the run service inside the upload service
- update `UploadParams` model