### PR TITLE
run: add support plan and milestone

### DIFF
--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -13,6 +13,8 @@ const (
 	titleFlag       = "title"
 	descriptionFlag = "description"
 	environmentFlag = "environment"
+	milestoneFlag   = "milestone"
+	planFlag        = "plan"
 )
 
 // Command returns a new cobra command for create runs
@@ -21,6 +23,8 @@ func Command() *cobra.Command {
 		title       string
 		description string
 		environment string
+		milestone   string
+		plan        string
 	)
 
 	cmd := &cobra.Command{
@@ -34,7 +38,7 @@ func Command() *cobra.Command {
 			c := client.NewClientV1(token)
 			s := run.NewService(c)
 
-			id, err := s.CreateRun(cmd.Context(), project, title, description, environment)
+			id, err := s.CreateRun(cmd.Context(), project, title, description, environment, milestone, plan)
 			if err != nil {
 				return err
 			}
@@ -52,6 +56,8 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the test run")
 	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "environment of the test run")
+	cmd.Flags().StringVarP(&milestone, milestoneFlag, "m", "", "milestone of the test run")
+	cmd.Flags().StringVar(&plan, planFlag, "", "plan of the test run")
 
 	return cmd
 }

--- a/internal/models/run/environment.go
+++ b/internal/models/run/environment.go
@@ -1,7 +1,0 @@
-package run
-
-type Environment struct {
-	Title string `json:"title"`
-	ID    int64  `json:"id"`
-	Slug  string `json:"slug"`
-}

--- a/internal/models/run/models.go
+++ b/internal/models/run/models.go
@@ -1,0 +1,17 @@
+package run
+
+type Environment struct {
+	Title string `json:"title"`
+	ID    int64  `json:"id"`
+	Slug  string `json:"slug"`
+}
+
+type Milestone struct {
+	Title string `json:"title"`
+	ID    int64  `json:"id"`
+}
+
+type Plan struct {
+	Title string `json:"title"`
+	ID    int64  `json:"id"`
+}

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -15,7 +15,7 @@ type Parser interface {
 }
 
 type runService interface {
-	CreateRun(ctx context.Context, p, t string, d, e string) (int64, error)
+	CreateRun(ctx context.Context, p, t string, d, e, m, plan string) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
@@ -51,7 +51,7 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) {
 
 	isTestRunCreated := false
 	if p.RunID == 0 {
-		runID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "")
+		runID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", "", "")
 		if err != nil {
 			logger.Error("failed to create run", "error", err)
 			return


### PR DESCRIPTION
clientv1: add new methods
--
- add `GetMilestones` method
- add `GetPlans` method
- update signature of the create test run method
- add `milestone` and `plan` models

---

run: add support plan and milestone
--
- add `plan` and `milestone` parameters
- update internal logic of the run service

---
upload: add support new signature of the run service