### PR TITLE
ci: always build Docker, tag with :tag and :latest

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Define the tag for the Docker image
+        # actions/checkout is making a shallow copy, so unless it's a tag event,
+        # tag will be empty; in such case, use shortened commit SHA
+        id: tag
+        run: echo "TAG=$(git describe --tags || git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -85,8 +85,7 @@ jobs:
 
   build-docker-n-publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.ref, 'refs/tags')
-    needs: build-n-publish
+    needs: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -116,8 +115,8 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          push: true
-          tags: ghcr.io/qase-tms/qase:${{ env.TAG }}
+          push: ${{ startsWith(github.event.ref, 'refs/tags') }}
+          tags: ghcr.io/qase-tms/qase:${{ env.TAG }},ghcr.io/qase-tms/qase:latest
           platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ env.TAG }}

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ coverage:
 
 .PHONY: docker
 docker:
-	@docker build -t qase:$(version) -f ./build/Dockerfile --build-arg VERSION=$(version) .
+	@docker build -t ghcr.io/qase-tms/qase:$(version) -t ghcr.io/qase-tms/qase:$latest -f ./build/Dockerfile --build-arg VERSION=$(version) .


### PR DESCRIPTION
# ci: define env.TAG value in Docker builds

* On tag pushes, use the tag name;
* On commit pushes, use the commit's shortened SHA


# ci: always build Docker, tag as :tag and :latest

* Build Docker images on every push event, but push to registry only
  on git tag pushes.
* Make the build-docker-n-publish job dependent on `test` job and not
  the other build job, which only runs on git tag pushes.
* Makefile: build images both with `version` and `latest`, so that they
  both can be pushed to registry.
  