### PR TITLE
create: change store test run ID method

### DIFF
--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"log/slog"
 	"os"
-	"strconv"
+	"path"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 	environmentFlag = "environment"
 	milestoneFlag   = "milestone"
 	planFlag        = "plan"
-	runIDEnv        = "QASE_TESTOPS_RUN_ID"
+	outputFlag      = "output"
 )
 
 // Command returns a new cobra command for create runs
@@ -29,6 +29,7 @@ func Command() *cobra.Command {
 		environment string
 		milestone   string
 		plan        string
+		output      string
 	)
 
 	cmd := &cobra.Command{
@@ -47,9 +48,17 @@ func Command() *cobra.Command {
 				return fmt.Errorf("failed to create run: %w", err)
 			}
 
-			err = os.Setenv(runIDEnv, strconv.Itoa(int(id)))
+			if output == "" {
+				dir, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to get current directory: %w", err)
+				}
+				output = path.Join(dir, "qase.env")
+			}
+
+			err = os.WriteFile(output, []byte(fmt.Sprintf("QASE_TESTOPS_RUN_ID=%d", id)), 0644)
 			if err != nil {
-				return fmt.Errorf("failed to set %s environment variable: %w", runIDEnv, err)
+				return fmt.Errorf("failed to write run ID to file: %w", err)
 			}
 
 			slog.Info(fmt.Sprintf("Run created with ID: %d", id))
@@ -67,6 +76,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "environment of the test run")
 	cmd.Flags().StringVarP(&milestone, milestoneFlag, "m", "", "milestone of the test run")
 	cmd.Flags().StringVar(&plan, planFlag, "", "plan of the test run")
+	cmd.Flags().StringVarP(&output, outputFlag, "o", "", "output path for the test run ID")
 
 	return cmd
 }

--- a/docs/command.md
+++ b/docs/command.md
@@ -1,7 +1,23 @@
 # Create a test run
 
 You can create a test run by using the `create` command. The `create` command is used to create a new test run in the
-specified project.
+specified project and save a test run ID to a file. You can specify the file path using the `--output` option. If the
+file path is not specified, the test run ID will be saved to `qase.env` in the current directory.
+
+The file will contain the test run ID in the following format:
+
+```text
+QASE_TESTOPS_RUN_ID=123
+```
+
+You can use the test run ID in subsequent steps to upload test results for the test run.
+For exctract test run ID from file you can use command:
+
+```bash
+cat qase.env | grep QASE_TESTOPS_RUN_ID | cut -d'=' -f2
+```
+
+## Example usage:
 
 ```bash
 qli testops run create --project <project_code> --token <token> --title <title> --description <description> --environment <environment> --milestone <milestone> --plan <plan> --verbose
@@ -16,6 +32,8 @@ The `create` command has the following options:
 - `--environment`, `-e`: The environment where the test run will be executed. Optional.
 - `--milestone`, `-m`: The milestone of the test run. Optional.
 - `--plan`: The test plan of the test run. Optional.
+- `--output`, `-o`: The output path to save the test run ID. Optional. Default is `qase.env` in the current
+  directory.
 - `--verbose`, `-v`: Enable verbose mode. Optional.
 
 The following example shows how to create a test run in the project with the code `PROJ`:
@@ -28,6 +46,8 @@ qli testops run create --project PROJ --token <token> --title "Test Run 1" --des
 
 You can complete a test run by using the `complete` command. The `complete` command is used to complete a test run in
 the specified project.
+
+## Example usage:
 
 ```bash
 qli testops run complete --project <project_code> --token <token> --run <run_id> --verbose
@@ -50,6 +70,8 @@ qli testops run complete --project PROJ --token <token> --run 1 --verbose
 
 You can upload test results by using the `upload` command. The `upload` command is used to upload test results for a
 test run in the specified project.
+
+## Example usage:
 
 ```bash
 qli testops result upload --project <project_code> --token <token> --id <run_id> --format <format> --path <results_file> --batch <batch> --verbose
@@ -82,14 +104,16 @@ with the code `PROJ`:
 qli testops result upload --project PROJ --token <token> --id 1 --format qase --path /path/to/results.json --verbose
 ```
 
-The following example shows how to upload test results in the Allure format for a test run with the ID `1` in the project
+The following example shows how to upload test results in the Allure format for a test run with the ID `1` in the
+project
 with the code `PROJ`:
 
 ```bash
 qli testops result upload --project PROJ --token <token> --id 1 --format allure --path /path/to/allure-results --verbose
 ```
 
-The following example shows how to upload test results in the XCTest format for a test run with the ID `1` in the project
+The following example shows how to upload test results in the XCTest format for a test run with the ID `1` in the
+project
 with the code `PROJ`:
 
 ```bash


### PR DESCRIPTION
create: change store test run ID method
--
Save the test run ID to a file. You can set file path by `output` parameter or the tool will use execution path.