### PR TITLE
feature: update create test run command

### DIFF
--- a/cmd/testops/env/create/create.go
+++ b/cmd/testops/env/create/create.go
@@ -59,12 +59,12 @@ func Command() *cobra.Command {
 				output = path.Join(dir, "qase.env")
 			}
 
-			err = os.WriteFile(output, []byte(fmt.Sprintf("QASE_ENVIRONMENT=%d", e.ID)), 0644)
+			err = os.WriteFile(output, []byte(fmt.Sprintf("QASE_ENVIRONMENT=%s", e.Slug)), 0644)
 			if err != nil {
-				return fmt.Errorf("failed to write environament ID to file: %w", err)
+				return fmt.Errorf("failed to write environament slug to file: %w", err)
 			}
 
-			slog.Info(fmt.Sprintf("Environment created with ID: %d", e.ID))
+			slog.Info(fmt.Sprintf("Environment created with slug: %s", e.Slug))
 
 			return nil
 		},

--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -27,8 +27,8 @@ func Command() *cobra.Command {
 		title       string
 		description string
 		environment string
-		milestone   string
-		plan        string
+		milestone   int64
+		plan        int64
 		output      string
 	)
 
@@ -73,9 +73,9 @@ func Command() *cobra.Command {
 		fmt.Println(err)
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the test run")
-	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "environment of the test run")
-	cmd.Flags().StringVarP(&milestone, milestoneFlag, "m", "", "milestone of the test run")
-	cmd.Flags().StringVar(&plan, planFlag, "", "plan of the test run")
+	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "slug of environment of the test run")
+	cmd.Flags().Int64VarP(&milestone, milestoneFlag, "m", 0, "ID of milestone of the test run")
+	cmd.Flags().Int64Var(&plan, planFlag, 0, "ID of plan of the test run")
 	cmd.Flags().StringVarP(&output, outputFlag, "o", "", "output path for the test run ID")
 
 	return cmd

--- a/internal/service/result/mocks/result.go
+++ b/internal/service/result/mocks/result.go
@@ -130,7 +130,7 @@ func (mr *MockrunServiceMockRecorder) CompleteRun(ctx, projectCode, runId any) *
 }
 
 // CreateRun mocks base method.
-func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e, m, plan string) (int64, error) {
+func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e string, m, plan int64) (int64, error) {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "CreateRun", ctx, p, t, d, e, m, plan)
 	ret0, _ := ret[0].(int64)

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -18,7 +18,7 @@ type Parser interface {
 
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type runService interface {
-	CreateRun(ctx context.Context, p, t string, d, e, m, plan string) (int64, error)
+	CreateRun(ctx context.Context, p, t string, d, e string, m, plan int64) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
@@ -54,7 +54,7 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) {
 	runID := p.RunID
 	isTestRunCreated := false
 	if runID == 0 {
-		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", "", "")
+		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0)
 		if err != nil {
 			logger.Error("failed to create run", "error", err)
 			return

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -337,7 +337,7 @@ func TestService_Upload(t *testing.T) {
 			}
 
 			if tt.rArgs.isUsed {
-				f.rs.EXPECT().CreateRun(gomock.Any(), tt.args.p.Project, tt.args.p.Title, tt.args.p.Description, "", "", "").Return(tt.rArgs.model, tt.rArgs.err)
+				f.rs.EXPECT().CreateRun(gomock.Any(), tt.args.p.Project, tt.args.p.Title, tt.args.p.Description, "", int64(0), int64(0)).Return(tt.rArgs.model, tt.rArgs.err)
 			}
 
 			if tt.cArgs.isUsed {

--- a/internal/service/run/mocks/run.go
+++ b/internal/service/run/mocks/run.go
@@ -83,33 +83,3 @@ func (mr *MockclientMockRecorder) GetEnvironments(ctx, projectCode any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironments", reflect.TypeOf((*Mockclient)(nil).GetEnvironments), ctx, projectCode)
 }
-
-// GetMilestones mocks base method.
-func (m *Mockclient) GetMilestones(ctx context.Context, projectCode, milestoneName string) ([]run.Milestone, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMilestones", ctx, projectCode, milestoneName)
-	ret0, _ := ret[0].([]run.Milestone)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMilestones indicates an expected call of GetMilestones.
-func (mr *MockclientMockRecorder) GetMilestones(ctx, projectCode, milestoneName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMilestones", reflect.TypeOf((*Mockclient)(nil).GetMilestones), ctx, projectCode, milestoneName)
-}
-
-// GetPlans mocks base method.
-func (m *Mockclient) GetPlans(ctx context.Context, projectCode string) ([]run.Plan, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlans", ctx, projectCode)
-	ret0, _ := ret[0].([]run.Plan)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPlans indicates an expected call of GetPlans.
-func (mr *MockclientMockRecorder) GetPlans(ctx, projectCode any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlans", reflect.TypeOf((*Mockclient)(nil).GetPlans), ctx, projectCode)
-}

--- a/internal/service/run/run.go
+++ b/internal/service/run/run.go
@@ -11,8 +11,6 @@ import (
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type client interface {
 	GetEnvironments(ctx context.Context, projectCode string) ([]run.Environment, error)
-	GetMilestones(ctx context.Context, projectCode, milestoneName string) ([]run.Milestone, error)
-	GetPlans(ctx context.Context, projectCode string) ([]run.Plan, error)
 	CreateRun(ctx context.Context, projectCode, title, description string, envID, mileID, planID int64) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
@@ -28,7 +26,7 @@ func NewService(client client) *Service {
 }
 
 // CreateRun creates a new run
-func (s *Service) CreateRun(ctx context.Context, pc, t, d, e, m, plan string) (int64, error) {
+func (s *Service) CreateRun(ctx context.Context, pc, t, d, e string, m, plan int64) (int64, error) {
 	var envID int64 = 0
 	if e != "" {
 		es, err := s.client.GetEnvironments(ctx, pc)
@@ -42,31 +40,7 @@ func (s *Service) CreateRun(ctx context.Context, pc, t, d, e, m, plan string) (i
 		}
 	}
 
-	var mileID int64 = 0
-	if m != "" {
-		ms, err := s.client.GetMilestones(ctx, pc, m)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get milestones: %w", err)
-		}
-		if len(ms) != 0 {
-			mileID = ms[0].ID
-		}
-	}
-
-	var planID int64 = 0
-	if plan != "" {
-		plans, err := s.client.GetPlans(ctx, pc)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get plans: %w", err)
-		}
-		for _, p := range plans {
-			if p.Title == plan {
-				planID = p.ID
-			}
-		}
-	}
-
-	return s.client.CreateRun(ctx, pc, t, d, envID, mileID, planID)
+	return s.client.CreateRun(ctx, pc, t, d, envID, m, plan)
 }
 
 // CompleteRun completes a run

--- a/internal/service/run/run_test.go
+++ b/internal/service/run/run_test.go
@@ -69,28 +69,18 @@ func TestService_CreateRun(t *testing.T) {
 		t    string
 		d    string
 		e    string
-		m    string
-		plan string
+		m    int64
+		plan int64
 		args baseArgs
-	}
-	type mArgs struct {
-		models []run.Milestone
-		args   baseArgs
 	}
 	type eArgs struct {
 		models []run.Environment
 		args   baseArgs
 	}
-	type pArgs struct {
-		models []run.Plan
-		args   baseArgs
-	}
 	tests := []struct {
 		name       string
 		args       args
-		mArgs      mArgs
 		eArgs      eArgs
-		pArgs      pArgs
 		want       int64
 		wantErr    bool
 		errMessage string
@@ -102,20 +92,8 @@ func TestService_CreateRun(t *testing.T) {
 				t:    "test",
 				d:    "test",
 				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
+				m:    0,
+				plan: 0,
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -127,18 +105,6 @@ func TestService_CreateRun(t *testing.T) {
 						ID:   1,
 						Slug: "test",
 					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -155,20 +121,8 @@ func TestService_CreateRun(t *testing.T) {
 				t:    "test",
 				d:    "test",
 				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
+				m:    0,
+				plan: 0,
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -185,18 +139,6 @@ func TestService_CreateRun(t *testing.T) {
 					isUsed: true,
 				},
 			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
 			want:       1,
 			wantErr:    false,
 			errMessage: "",
@@ -208,20 +150,8 @@ func TestService_CreateRun(t *testing.T) {
 				t:    "test",
 				d:    "test",
 				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: false,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
+				m:    0,
+				plan: 0,
 				args: baseArgs{
 					err:    nil,
 					isUsed: false,
@@ -233,230 +163,6 @@ func TestService_CreateRun(t *testing.T) {
 						ID:   0,
 						Slug: "test",
 					}},
-				args: baseArgs{
-					err:    errors.New("error"),
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: false,
-				},
-			},
-			want:       0,
-			wantErr:    true,
-			errMessage: "failed to get environments: error",
-		},
-		{
-			name: "milestone not found",
-			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    0,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			eArgs: eArgs{
-				models: []run.Environment{
-					{
-						ID:   1,
-						Slug: "test",
-					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			want:       1,
-			wantErr:    false,
-			errMessage: "",
-		},
-		{
-			name: "failed to get milestones",
-			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: false,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    errors.New("error"),
-					isUsed: true,
-				},
-			},
-			eArgs: eArgs{
-				models: []run.Environment{
-					{
-						ID:   0,
-						Slug: "test",
-					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: false,
-				},
-			},
-			want:       0,
-			wantErr:    true,
-			errMessage: "failed to get milestones: error",
-		},
-		{
-			name: "plan not found",
-			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    0,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			eArgs: eArgs{
-				models: []run.Environment{
-					{
-						ID:   1,
-						Slug: "test",
-					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    0,
-						Title: "test1",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			want:       1,
-			wantErr:    false,
-			errMessage: "",
-		},
-		{
-			name: "failed to get plans",
-			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    "test",
-				plan: "test",
-				args: baseArgs{
-					err:    nil,
-					isUsed: false,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			eArgs: eArgs{
-				models: []run.Environment{
-					{
-						ID:   0,
-						Slug: "test",
-					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
 				args: baseArgs{
 					err:    errors.New("error"),
 					isUsed: true,
@@ -464,7 +170,7 @@ func TestService_CreateRun(t *testing.T) {
 			},
 			want:       0,
 			wantErr:    true,
-			errMessage: "failed to get plans: error",
+			errMessage: "failed to get environments: error",
 		},
 		{
 			name: "failed to create run",
@@ -473,22 +179,10 @@ func TestService_CreateRun(t *testing.T) {
 				t:    "test",
 				d:    "test",
 				e:    "test",
-				m:    "test",
-				plan: "test",
+				m:    0,
+				plan: 0,
 				args: baseArgs{
 					err:    errors.New("error"),
-					isUsed: true,
-				},
-			},
-			mArgs: mArgs{
-				models: []run.Milestone{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
-				args: baseArgs{
-					err:    nil,
 					isUsed: true,
 				},
 			},
@@ -498,18 +192,6 @@ func TestService_CreateRun(t *testing.T) {
 						ID:   0,
 						Slug: "test",
 					}},
-				args: baseArgs{
-					err:    nil,
-					isUsed: true,
-				},
-			},
-			pArgs: pArgs{
-				models: []run.Plan{
-					{
-						ID:    1,
-						Title: "test",
-					},
-				},
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -527,12 +209,6 @@ func TestService_CreateRun(t *testing.T) {
 			if tt.eArgs.args.isUsed {
 				f.client.EXPECT().GetEnvironments(gomock.Any(), tt.args.pc).Return(tt.eArgs.models, tt.eArgs.args.err)
 			}
-			if tt.mArgs.args.isUsed {
-				f.client.EXPECT().GetMilestones(gomock.Any(), tt.args.pc, tt.args.m).Return(tt.mArgs.models, tt.mArgs.args.err)
-			}
-			if tt.pArgs.args.isUsed {
-				f.client.EXPECT().GetPlans(gomock.Any(), tt.args.pc).Return(tt.pArgs.models, tt.pArgs.args.err)
-			}
 
 			if tt.args.args.isUsed {
 				f.client.EXPECT().CreateRun(gomock.Any(),
@@ -540,8 +216,8 @@ func TestService_CreateRun(t *testing.T) {
 					tt.args.t,
 					tt.args.d,
 					tt.eArgs.models[0].ID,
-					tt.mArgs.models[0].ID,
-					tt.pArgs.models[0].ID,
+					tt.args.m,
+					tt.args.plan,
 				).
 					Return(tt.want, tt.args.args.err)
 			}


### PR DESCRIPTION
feature: change type of parameters for the create test run command
--
Change `milestone` and `plan` types from `string` to `int64`. These parameters will take ID of entities.

---

test: update unit tests
--
Update the unit tests for `run` and `result` services

---

feature: change an output value for the create environment command
--
Change the output value for the create environment command from `ID` to `slug`