### PR TITLE
feature: mark a test run as automated when created

### DIFF
--- a/internal/client/clientv1.go
+++ b/internal/client/clientv1.go
@@ -245,6 +245,8 @@ func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, des
 		Title: title,
 	}
 
+	m.SetIsAutotest(true)
+
 	if description != "" {
 		m.SetDescription(description)
 	}


### PR DESCRIPTION
feature: mark a test run as automated when created
--
This behavior will work by default for all created test runs.