### PR TITLE
fix: panic caused by out-of-range slice in batch processing

### DIFF
--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -82,7 +82,13 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) {
 		}
 	} else {
 		for i := int64(0); i < int64(len(results)); i += p.Batch {
-			err := s.client.UploadData(ctx, p.Project, runID, results[i:i+p.Batch])
+			end := i + p.Batch
+
+			if end > int64(len(results)) {
+				end = int64(len(results))
+			}
+
+			err := s.client.UploadData(ctx, p.Project, runID, results[i:end])
 			if err != nil {
 				logger.Error("failed to upload results", "error", err)
 			}


### PR DESCRIPTION
- Added a boundary check to ensure the slice end index does not exceed the length of the results array.
 - Prevents runtime error when the remaining elements are fewer than the batch size.