### PR TITLE
feat: add GitHub Actions pipeline for cross-platform release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Create Release on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ linux, windows, darwin ]
+        arch: [ amd64, arm64 ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build the binary for ${{ matrix.os }}-${{ matrix.arch }}
+        run: |
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./cmd
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          RELEASE_NOTES=$(git log --oneline $(git describe --tags --abbrev=0)..HEAD)
+          echo "::set-output name=notes::$RELEASE_NOTES"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/qasectl-linux-amd64
+            build/qasectl-linux-arm64
+            build/qasectl-darwin-amd64
+            build/qasectl-darwin-arm64
+            build/qasectl-windows-amd64.exe
+            build/qasectl-windows-arm64.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: Release ${{ github.ref }}
+          BODY: ${{ steps.release_notes.outputs.notes }}


### PR DESCRIPTION
- Configured GitHub Actions to build binaries for Linux, macOS, and Windows
- Added support for amd64 and arm64 architectures
- Automatically generates release notes and attaches compiled binaries to the GitHub release
- Ensures cross-platform compatibility for the release artifacts

#57