### PR TITLE
fix: display correct version when build version is not set

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/qase-tms/qasectl/internal"
 	"github.com/spf13/cobra"
+	"runtime/debug"
 )
 
 func VersionCmd() *cobra.Command {
@@ -13,6 +14,11 @@ func VersionCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if internal.Version == "" {
+				info, ok := debug.ReadBuildInfo()
+				if ok && info.Main.Version != "(devel)" {
+					fmt.Println("Qase CLI " + info.Main.Version)
+					return
+				}
 				fmt.Println("Qase CLI: version not set during build.")
 			} else {
 				fmt.Println("Qase CLI " + internal.Version)


### PR DESCRIPTION
- Added fallback to retrieve version from module build info when version is not provided via build flags