### PR TITLE
ci: change modifies the path of the Go source file used for building the binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Build the binary for ${{ matrix.os }}-${{ matrix.arch }}
         run: |
           if [ "${{ matrix.os }}" == "windows" ]; then
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./cmd
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./main.go
           else
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./cmd
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./main.go
           fi
 
       - name: Create GitHub release


### PR DESCRIPTION
This pull request includes a change to the build process in the GitHub Actions workflow configuration file. The change modifies the path of the Go source file used for building the binary.

Build process modification:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R33): Changed the Go source file path from `./cmd` to `./main.go` for building the binary for different operating systems and architectures.