### PR TITLE
ci: use a tag for the app version during the build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,16 @@ jobs:
         with:
           go-version: '1.21'
 
+      - name: Define the tag for the app version
+        id: tag
+        run: echo "TAG=$(git describe --tags || git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build the binary for ${{ matrix.os }}-${{ matrix.arch }}
         run: |
           if [ "${{ matrix.os }}" == "windows" ]; then
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./main.go
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./main.go
           else
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./main.go
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./main.go
           fi
 
       - name: Create GitHub release


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow to define and use a tag for the app version during the build process. The most important change is the addition of a step to define the tag and the modification of the build commands to include this tag.

Changes to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R28-R37): Added a step to define the tag for the app version and modified the build commands to include the tag in the `-ldflags` option.