### PR TITLE
ci: change corrects the order of the `-o` and `-ldflags` options in the `go build` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Build the binary for ${{ matrix.os }}-${{ matrix.arch }}
         run: |
           if [ "${{ matrix.os }}" == "windows" ]; then
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./main.go
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}.exe" ./main.go
           else
-            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./main.go
+            GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -ldflags="-X github.com/qase-tms/qasectl/internal.Version=${{ env.TAG }}" -o "build/qasectl-${{ matrix.os }}-${{ matrix.arch }}" ./main.go
           fi
 
       - name: Create GitHub release


### PR DESCRIPTION
This pull request includes a small but important change to the `jobs:` section in the `.github/workflows/release.yml` file. The change corrects the order of the `-o` and `-ldflags` options in the `go build` command to ensure proper flag usage.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R37): Corrected the order of the `-o` and `-ldflags` options in the `go build` command for both Windows and other operating systems.