### PR TITLE
chore(cli): rename executable from `qli` to `qasectl`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@
 .DS_Store
 
 qasectl
-qli

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ version := $(shell git describe --tags)
 .PHONY: build
 build:
 	@mkdir -p build
-	@go build -a -ldflags="-X github.com/qase-tms/qasectl/internal.Version=$(version)" -o build/qli ./main.go
+	@go build -a -ldflags="-X github.com/qase-tms/qasectl/internal.Version=$(version)" -o build/qasectl ./main.go
 
 clean:
-	@rm -rf ./build/qli
+	@rm -rf ./build/qasectl
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qase CLI
 
-`qli` is the command-line interface (CLI) for Qase, enabling users to interact with test runs and import test results
+`qasectl` is the command-line interface (CLI) for Qase, enabling users to interact with test runs and import test results
 directly from the terminal.
 
 Qase CLI is available for both **Qase** and **Qase Enterprise** users.
@@ -53,10 +53,10 @@ You can also use Qase CLI via Docker. Follow these steps:
 
 ## Usage
 
-`qli` is designed to be used directly in your terminal. You can run the following command to view available options:
+`qasectl` is designed to be used directly in your terminal. You can run the following command to view available options:
 
 ```bash
-qli --help
+qasectl --help
 ```
 
 This will show all available commands and their descriptions.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,10 +13,10 @@ COPY . ./
 
 RUN go mod download
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -ldflags="-X github.com/qase-tms/qasectl/internal.Version=$VERSION" -o /qli ./main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -ldflags="-X github.com/qase-tms/qasectl/internal.Version=$VERSION" -o /qasectl ./main.go
 
 FROM --platform=${TARGETPLATFORM} alpine:3.20 as final
 
-COPY --from=builder /qli /usr/local/bin/qli
+COPY --from=builder /qasectl /usr/local/bin/qasectl
 
-ENTRYPOINT ["qli"]
+ENTRYPOINT ["qasectl"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "qli",
+	Use:   "qasectl",
 	Short: "CLI tool for Qase TestOps",
 }
 

--- a/cmd/testops/env/create/create.go
+++ b/cmd/testops/env/create/create.go
@@ -34,7 +34,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a new environment",
-		Example: "qli testops env create --title 'New environment' --slug local --description 'This is a environment' --host app.server.com --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops env create --title 'New environment' --slug local --description 'This is a environment' --host app.server.com --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if strings.Contains(slug, " ") {
 				return fmt.Errorf("slug can't contain spaces")

--- a/cmd/testops/milestone/create/create.go
+++ b/cmd/testops/milestone/create/create.go
@@ -34,7 +34,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a new milestone",
-		Example: "qli testops milestone create --title 'New milestone' --description 'This is a milestone' --status active --due-date 2024-01-30 --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops milestone create --title 'New milestone' --description 'This is a milestone' --status active --due-date 2024-01-30 --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if status != "" && status != "active" && status != "completed" {
 				return fmt.Errorf("invalid status value: %s. allowed values: active, completed", status)

--- a/cmd/testops/result/upload/upload.go
+++ b/cmd/testops/result/upload/upload.go
@@ -39,7 +39,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upload",
 		Short:   "Upload test results",
-		Example: "qli testops result upload --path 'path' --format 'junit' --id 123 --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops result upload --path 'path' --format 'junit' --id 123 --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			const op = "upload"
 			logger := slog.With("op", op)

--- a/cmd/testops/run/complete/complete.go
+++ b/cmd/testops/run/complete/complete.go
@@ -22,7 +22,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "complete",
 		Short:   "Complete a test run",
-		Example: "qli testops run complete --id 123 --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops run complete --id 123 --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token := viper.GetString(flags.TokenFlag)
 			project := viper.GetString(flags.ProjectFlag)

--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -35,7 +35,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a new test run",
-		Example: "qli testops run create --title 'My test run' --description 'This is a test run' --environment local --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops run create --title 'My test run' --description 'This is a test run' --environment local --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token := viper.GetString(flags.TokenFlag)
 			project := viper.GetString(flags.ProjectFlag)

--- a/cmd/testops/run/delete/delete.go
+++ b/cmd/testops/run/delete/delete.go
@@ -30,7 +30,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "Delete test runs",
-		Example: "qli testops run delete --ids 1,2,3 --start 2024-01-02 --end 2024-12-31 --project 'PRJ' --token 'TOKEN'",
+		Example: "qasectl testops run delete --ids 1,2,3 --start 2024-01-02 --end 2024-12-31 --project 'PRJ' --token 'TOKEN'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token := viper.GetString(flags.TokenFlag)
 			project := viper.GetString(flags.ProjectFlag)

--- a/docs/command.md
+++ b/docs/command.md
@@ -20,7 +20,7 @@ cat qase.env | grep QASE_TESTOPS_RUN_ID | cut -d'=' -f2
 ## Example usage:
 
 ```bash
-qli testops run create --project <project_code> --token <token> --title <title> --description <description> --environment <environment> --milestone <milestone> --plan <plan> --verbose
+qasectl testops run create --project <project_code> --token <token> --title <title> --description <description> --environment <environment> --milestone <milestone> --plan <plan> --verbose
 ```
 
 The `create` command has the following options:
@@ -39,7 +39,7 @@ The `create` command has the following options:
 The following example shows how to create a test run in the project with the code `PROJ`:
 
 ```bash
-qli testops run create --project PROJ --token <token> --title "Test Run 1" --description "This is a test run" --environment "Production" --milestone "Milestone 1" --plan "Test Plan 1" --verbose
+qasectl testops run create --project PROJ --token <token> --title "Test Run 1" --description "This is a test run" --environment "Production" --milestone "Milestone 1" --plan "Test Plan 1" --verbose
 ```
 
 # Complete a test run
@@ -50,7 +50,7 @@ the specified project.
 ## Example usage:
 
 ```bash
-qli testops run complete --project <project_code> --token <token> --id <run_id> --verbose
+qasectl testops run complete --project <project_code> --token <token> --id <run_id> --verbose
 ```
 
 The `complete` command has the following options:
@@ -63,7 +63,7 @@ The `complete` command has the following options:
 The following example shows how to complete a test run with the ID `1` in the project with the code `PROJ`:
 
 ```bash
-qli testops run complete --project PROJ --token <token> --id 1 --verbose
+qasectl testops run complete --project PROJ --token <token> --id 1 --verbose
 ```
 
 # Delete test runs
@@ -74,7 +74,7 @@ specified project.
 ## Example usage:
 
 ```bash
-qli testops run delete --project <project_code> --token <token> --ids <run_id> --verbose
+qasectl testops run delete --project <project_code> --token <token> --ids <run_id> --verbose
 ```
 
 The `delete` command has the following options:
@@ -90,20 +90,20 @@ The `delete` command has the following options:
 The following example shows how to delete a test run with the ID `1` in the project with the code `PROJ`:
 
 ```bash
-qli testops run delete --project PROJ --token <token> --ids 1 --verbose
+qasectl testops run delete --project PROJ --token <token> --ids 1 --verbose
 ```
 
 The following example shows how to delete all test runs in the project with the code `PROJ`:
 
 ```bash
-qli testops run delete --project PROJ --token <token> --all --verbose
+qasectl testops run delete --project PROJ --token <token> --all --verbose
 ```
 
 The following example shows how to delete all test runs in the project with the code `PROJ` that were created between
 `2022-01-01` and `2022-12-31`:
 
 ```bash
-qli testops run delete --project PROJ --token <token> --all --start "2022-01-01" --end "2022-12-31" --verbose
+qasectl testops run delete --project PROJ --token <token> --all --start "2022-01-01" --end "2022-12-31" --verbose
 ```
 
 # Upload test results
@@ -114,7 +114,7 @@ test run in the specified project.
 ## Example usage:
 
 ```bash
-qli testops result upload --project <project_code> --token <token> --id <run_id> --format <format> --path <results_file> --batch <batch> --verbose
+qasectl testops result upload --project <project_code> --token <token> --id <run_id> --format <format> --path <results_file> --batch <batch> --verbose
 ```
 
 The `upload` command has the following options:
@@ -135,14 +135,14 @@ The following example shows how to upload test results in the JUnit format for a
 with the code `PROJ`:
 
 ```bash
-qli testops result upload --project PROJ --token <token> --id 1 --format junit --path /path/to/results.xml --verbose
+qasectl testops result upload --project PROJ --token <token> --id 1 --format junit --path /path/to/results.xml --verbose
 ```
 
 The following example shows how to upload test results in the Qase format for a test run with the ID `1` in the project
 with the code `PROJ`:
 
 ```bash
-qli testops result upload --project PROJ --token <token> --id 1 --format qase --path /path/to/results.json --verbose
+qasectl testops result upload --project PROJ --token <token> --id 1 --format qase --path /path/to/results.json --verbose
 ```
 
 The following example shows how to upload test results in the Allure format for a test run with the ID `1` in the
@@ -150,7 +150,7 @@ project
 with the code `PROJ`:
 
 ```bash
-qli testops result upload --project PROJ --token <token> --id 1 --format allure --path /path/to/allure-results --verbose
+qasectl testops result upload --project PROJ --token <token> --id 1 --format allure --path /path/to/allure-results --verbose
 ```
 
 The following example shows how to upload test results in the XCTest format for a test run with the ID `1` in the
@@ -158,7 +158,7 @@ project
 with the code `PROJ`:
 
 ```bash
-qli testops result upload --project PROJ --token <token> --id 1 --format xctest --steps user --path /path/to/xctest-results --verbose
+qasectl testops result upload --project PROJ --token <token> --id 1 --format xctest --steps user --path /path/to/xctest-results --verbose
 ```
 
 # Create an environment
@@ -184,7 +184,7 @@ cat qase.env | grep QASE_ENVIRONMENT | cut -d'=' -f2
 ## Example usage:
 
 ```bash
-qli testops env create --project <project_code> --token <token> --title <title> --slug <slug> --description <description> --host <host> --verbose
+qasectl testops env create --project <project_code> --token <token> --title <title> --slug <slug> --description <description> --host <host> --verbose
 ```
 
 The `create` command has the following options:
@@ -202,7 +202,7 @@ The `create` command has the following options:
 The following example shows how to create an environment in the project with the code `PROJ`:
 
 ```bash
-qli testops env create --title 'New environment' --slug local --description 'This is an environment' --host app.server.com --project 'PRJ' --token 'TOKEN' --output 'env.env' --verbose
+qasectl testops env create --title 'New environment' --slug local --description 'This is an environment' --host app.server.com --project 'PRJ' --token 'TOKEN' --output 'env.env' --verbose
 ``` 
 
 # Create a milestone
@@ -227,7 +227,7 @@ cat qase.env | grep QASE_MILESTONE | cut -d'=' -f2
 ## Example usage:
 
 ```bash
-qli testops milestone create --project <project_code> --token <token> --title <title> --description <description> --status <status> --due-date <due_date> --verbose
+qasectl testops milestone create --project <project_code> --token <token> --title <title> --description <description> --status <status> --due-date <due_date> --verbose
 ```
 
 The `create` command has the following options:
@@ -244,5 +244,5 @@ The `create` command has the following options:
 The following example shows how to create a milestone in the project with the code `PROJ`:
 
 ```bash
-qli testops milestone create --project PROJ --token <token> --title "Milestone 1" --description "This is a milestone" --status active --due-date "2022-12-31" --verbose
+qasectl testops milestone create --project PROJ --token <token> --title "Milestone 1" --description "This is a milestone" --status active --due-date "2022-12-31" --verbose
 ```

--- a/docs/source.md
+++ b/docs/source.md
@@ -28,29 +28,29 @@
 
    #### Windows
    ```pwsh
-   # build the `bin\qli.exe` binary
+   # build the `bin\qasectl.exe` binary
    > go run script\build.go
    ```
    There is no install step available on Windows.
 
-4. Run `qli version` to check if it worked.
+4. Run `qasectl version` to check if it worked.
 
    #### Windows
-   Run `bin\qli version` to check if it worked.
+   Run `bin\qasectl version` to check if it worked.
 
 ## Cross-compiling binaries for different platforms
 
 You can use any platform with Go installed to build a binary that is intended for another platform
 or CPU architecture. This is achieved by setting environment variables such as GOOS and GOARCH.
 
-For example, to compile the `qli` binary for the 32-bit Raspberry Pi OS:
+For example, to compile the `qasectl` binary for the 32-bit Raspberry Pi OS:
 ```sh
 # on a Unix-like system:
-$ GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 make clean bin/qli
+$ GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 make clean bin/qasectl
 ```
 ```pwsh
 # on Windows, pass environment variables as arguments to the build script:
-> go run script\build.go clean bin\qli GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0
+> go run script\build.go clean bin\qasectl GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0
 ```
 
 Run `go tool dist list` to list all supported values of GOOS/GOARCH.

--- a/internal/parsers/allure/allure.go
+++ b/internal/parsers/allure/allure.go
@@ -59,7 +59,7 @@ func (p *Parser) Parse() ([]models.Result, error) {
 			if err != nil {
 				return fmt.Errorf("failed to walk path: %w", err)
 			}
-			if !info.IsDir() {
+			if !info.IsDir() && strings.Contains(path, "-result.json") {
 				files = append(files, path)
 			}
 			return nil


### PR DESCRIPTION
- Updated build configuration to generate `qasectl` as the CLI entry point
- Removed references to the old `qli` name