### PR TITLE
feat: add support for replacing result statuses in upload command

### DIFF
--- a/docs/command.md
+++ b/docs/command.md
@@ -129,6 +129,7 @@ The `upload` command has the following options:
 - `--steps`: The mode of upload steps for XCTest. Optional. Allow values: `all`, `user`.
 - `--batch`: The batch number of the test results. Optional. Default is 200.
 - `--suite`, `-s`: The suite name of the test results. Optional.
+- `--replace-statuses`, `-r`: The statuses to replace. Optional. Pass like '{\"Passed\": \"Failed\"}' to replace all passed results with failed. Note: Use slugs of statuses.
 - `--verbose`, `-v`: Enable verbose mode. Optional.
 
 The following example shows how to upload test results in the JUnit format for a test run with the ID `1` in the project

--- a/internal/service/result/models.go
+++ b/internal/service/result/models.go
@@ -7,4 +7,5 @@ type UploadParams struct {
 	Batch       int64
 	Project     string
 	Suite       string
+	Statuses    map[string]string
 }

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -3,10 +3,11 @@ package result
 import (
 	"context"
 	"fmt"
-	models "github.com/qase-tms/qasectl/internal/models/result"
-	"golang.org/x/sync/errgroup"
 	"log/slog"
 	"runtime"
+
+	models "github.com/qase-tms/qasectl/internal/models/result"
+	"golang.org/x/sync/errgroup"
 )
 
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
@@ -78,6 +79,14 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 
 		for i := range results {
 			results[i].Relations.Suite.Data = append(s, results[i].Relations.Suite.Data...)
+		}
+	}
+
+	if len(p.Statuses) > 0 {
+		for i := range results {
+			if status, ok := p.Statuses[results[i].Execution.Status]; ok {
+				results[i].Execution.Status = status
+			}
 		}
 	}
 

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -3,9 +3,10 @@ package result
 import (
 	"context"
 	"errors"
+	"testing"
+
 	models "github.com/qase-tms/qasectl/internal/models/result"
 	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 func TestService_Upload(t *testing.T) {
@@ -368,6 +369,54 @@ func TestService_Upload(t *testing.T) {
 			},
 			wantErr:    true,
 			errMessage: "failed complete run",
+		},
+		{
+			name: "success with status mapping",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       0,
+					Batch:       20,
+					Suite:       "",
+					Statuses: map[string]string{
+						"passed": "passed",
+						"failed": "failed",
+					},
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: []models.Result{
+					{
+						Execution: models.Execution{
+							Status: "passed",
+						},
+					},
+					{
+						Execution: models.Execution{
+							Status: "failed",
+						},
+					},
+				},
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: true,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: true,
+			},
+			wantErr:    false,
+			errMessage: "",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Introduced a new flag `--replace-statuses` to allow users to specify status mappings for test results.
- Updated the `UploadParams` structure to include a map for statuses.
- Enhanced the upload logic to apply the specified status replacements during the upload process.
- Updated documentation to reflect the new command option.