### PR TITLE
refactor: simplify result execution structure in XCTest parser

### DIFF
--- a/internal/parsers/xctest/xctest.go
+++ b/internal/parsers/xctest/xctest.go
@@ -306,10 +306,8 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 			Title:     t.Name,
 			Signature: &t.Signature,
 			Execution: models.Execution{
-				Status:    getStatus(t.Action.TestStatus.Value),
-				Duration:  &t.Duration,
-				StartTime: t.Metadata.StartTime,
-				EndTime:   t.Metadata.EndTime,
+				Status:   getStatus(t.Action.TestStatus.Value),
+				Duration: &t.Duration,
 			},
 			Fields:      map[string]string{},
 			Attachments: make([]models.Attachment, 0),


### PR DESCRIPTION
- Removed redundant fields from the execution structure in the getResults method.
- Streamlined the code for better readability and maintainability.