### PR TITLE
feat: add tags support to create run command

### DIFF
--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -2,14 +2,15 @@ package create
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
+	"path"
+
 	"github.com/qase-tms/qasectl/cmd/flags"
 	"github.com/qase-tms/qasectl/internal/client"
 	"github.com/qase-tms/qasectl/internal/service/run"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"log/slog"
-	"os"
-	"path"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 	milestoneFlag   = "milestone"
 	planFlag        = "plan"
 	outputFlag      = "output"
+	tagsFlag        = "tags"
 )
 
 // Command returns a new cobra command for create runs
@@ -30,6 +32,7 @@ func Command() *cobra.Command {
 		milestone   int64
 		plan        int64
 		output      string
+		tags        []string
 	)
 
 	cmd := &cobra.Command{
@@ -43,7 +46,7 @@ func Command() *cobra.Command {
 			c := client.NewClientV1(token)
 			s := run.NewService(c)
 
-			id, err := s.CreateRun(cmd.Context(), project, title, description, environment, milestone, plan)
+			id, err := s.CreateRun(cmd.Context(), project, title, description, environment, milestone, plan, tags)
 			if err != nil {
 				return fmt.Errorf("failed to create run: %w", err)
 			}
@@ -77,6 +80,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Int64VarP(&milestone, milestoneFlag, "m", 0, "ID of milestone of the test run")
 	cmd.Flags().Int64Var(&plan, planFlag, 0, "ID of plan of the test run")
 	cmd.Flags().StringVarP(&output, outputFlag, "o", "", "output path for the test run ID")
+	cmd.Flags().StringSliceVar(&tags, tagsFlag, []string{}, "tags of the test run")
 
 	return cmd
 }

--- a/docs/command.md
+++ b/docs/command.md
@@ -32,6 +32,7 @@ The `create` command has the following options:
 - `--environment`, `-e`: The environment where the test run will be executed. Optional.
 - `--milestone`, `-m`: The milestone of the test run. Optional.
 - `--plan`: The test plan of the test run. Optional.
+- `--tags`: The tags of the test run. Optional.
 - `--output`, `-o`: The output path to save the test run ID. Optional. Default is `qase.env` in the current
   directory.
 - `--verbose`, `-v`: Enable verbose mode. Optional.
@@ -39,7 +40,7 @@ The `create` command has the following options:
 The following example shows how to create a test run in the project with the code `PROJ`:
 
 ```bash
-qasectl testops run create --project PROJ --token <token> --title "Test Run 1" --description "This is a test run" --environment "Production" --milestone "Milestone 1" --plan "Test Plan 1" --verbose
+qasectl testops run create --project PROJ --token <token> --title "Test Run 1" --description "This is a test run" --environment "Production" --milestone "Milestone 1" --plan "Test Plan 1" --tags "tag1,tag2" --verbose
 ```
 
 # Complete a test run

--- a/internal/client/clientv1.go
+++ b/internal/client/clientv1.go
@@ -229,7 +229,7 @@ func (c *ClientV1) GetPlans(ctx context.Context, projectCode string) ([]run.Plan
 }
 
 // CreateRun creates a new run
-func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64) (int64, error) {
+func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string) (int64, error) {
 	const op = "client.clientv1.createrun"
 	logger := slog.With("op", op)
 
@@ -255,6 +255,10 @@ func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, des
 
 	if planID != 0 {
 		m.SetPlanId(planID)
+	}
+
+	if len(tags) > 0 {
+		m.SetTags(tags)
 	}
 
 	logger.Debug("creating run", "projectCode", projectCode, "model", m)

--- a/internal/service/result/mocks/result.go
+++ b/internal/service/result/mocks/result.go
@@ -130,16 +130,16 @@ func (mr *MockrunServiceMockRecorder) CompleteRun(ctx, projectCode, runId any) *
 }
 
 // CreateRun mocks base method.
-func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e string, m, plan int64) (int64, error) {
+func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e string, m, plan int64, tags []string) (int64, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "CreateRun", ctx, p, t, d, e, m, plan)
+	ret := m_2.ctrl.Call(m_2, "CreateRun", ctx, p, t, d, e, m, plan, tags)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRun indicates an expected call of CreateRun.
-func (mr *MockrunServiceMockRecorder) CreateRun(ctx, p, t, d, e, m, plan any) *gomock.Call {
+func (mr *MockrunServiceMockRecorder) CreateRun(ctx, p, t, d, e, m, plan, tags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*MockrunService)(nil).CreateRun), ctx, p, t, d, e, m, plan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*MockrunService)(nil).CreateRun), ctx, p, t, d, e, m, plan, tags)
 }

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -22,7 +22,7 @@ type Parser interface {
 
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type runService interface {
-	CreateRun(ctx context.Context, p, t string, d, e string, m, plan int64) (int64, error)
+	CreateRun(ctx context.Context, p, t string, d, e string, m, plan int64, tags []string) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
@@ -62,7 +62,7 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 	runID := p.RunID
 	isTestRunCreated := false
 	if runID == 0 {
-		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0)
+		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0, []string{})
 		if err != nil {
 			return err
 		}

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -428,7 +428,7 @@ func TestService_Upload(t *testing.T) {
 			}
 
 			if tt.rArgs.isUsed {
-				f.rs.EXPECT().CreateRun(gomock.Any(), tt.args.p.Project, tt.args.p.Title, tt.args.p.Description, "", int64(0), int64(0)).Return(tt.rArgs.model, tt.rArgs.err)
+				f.rs.EXPECT().CreateRun(gomock.Any(), tt.args.p.Project, tt.args.p.Title, tt.args.p.Description, "", int64(0), int64(0), []string{}).Return(tt.rArgs.model, tt.rArgs.err)
 			}
 
 			if tt.cArgs.isUsed {

--- a/internal/service/run/mocks/run.go
+++ b/internal/service/run/mocks/run.go
@@ -55,18 +55,18 @@ func (mr *MockclientMockRecorder) CompleteRun(ctx, projectCode, runId any) *gomo
 }
 
 // CreateRun mocks base method.
-func (m *Mockclient) CreateRun(ctx context.Context, projectCode, title, description, envSlug string, mileID, planID int64) (int64, error) {
+func (m *Mockclient) CreateRun(ctx context.Context, projectCode, title, description, envSlug string, mileID, planID int64, tags []string) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRun", ctx, projectCode, title, description, envSlug, mileID, planID)
+	ret := m.ctrl.Call(m, "CreateRun", ctx, projectCode, title, description, envSlug, mileID, planID, tags)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRun indicates an expected call of CreateRun.
-func (mr *MockclientMockRecorder) CreateRun(ctx, projectCode, title, description, envSlug, mileID, planID any) *gomock.Call {
+func (mr *MockclientMockRecorder) CreateRun(ctx, projectCode, title, description, envSlug, mileID, planID, tags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*Mockclient)(nil).CreateRun), ctx, projectCode, title, description, envSlug, mileID, planID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*Mockclient)(nil).CreateRun), ctx, projectCode, title, description, envSlug, mileID, planID, tags)
 }
 
 // DeleteTestRun mocks base method.

--- a/internal/service/run/run.go
+++ b/internal/service/run/run.go
@@ -10,7 +10,7 @@ import (
 //
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type client interface {
-	CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64) (int64, error)
+	CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 	GetTestRuns(ctx context.Context, projectCode string, start, end int64) ([]run.Run, error)
 	DeleteTestRun(ctx context.Context, projectCode string, id int64) error
@@ -27,8 +27,8 @@ func NewService(client client) *Service {
 }
 
 // CreateRun creates a new run
-func (s *Service) CreateRun(ctx context.Context, pc, t, d, e string, m, plan int64) (int64, error) {
-	return s.client.CreateRun(ctx, pc, t, d, e, m, plan)
+func (s *Service) CreateRun(ctx context.Context, pc, t, d, e string, m, plan int64, tags []string) (int64, error) {
+	return s.client.CreateRun(ctx, pc, t, d, e, m, plan, tags)
 }
 
 // CompleteRun completes a run

--- a/internal/service/run/run_test.go
+++ b/internal/service/run/run_test.go
@@ -3,10 +3,11 @@ package run
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/magiconair/properties/assert"
 	"github.com/qase-tms/qasectl/internal/models/run"
 	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 func TestService_CompleteRun(t *testing.T) {
@@ -71,6 +72,7 @@ func TestService_CreateRun(t *testing.T) {
 		e    string
 		m    int64
 		plan int64
+		tags []string
 		args baseArgs
 	}
 	tests := []struct {
@@ -89,6 +91,26 @@ func TestService_CreateRun(t *testing.T) {
 				e:    "test",
 				m:    0,
 				plan: 0,
+				tags: []string{},
+				args: baseArgs{
+					err:    nil,
+					isUsed: true,
+				},
+			},
+			want:       1,
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "success with tags",
+			args: args{
+				pc:   "test",
+				t:    "test",
+				d:    "test",
+				e:    "test",
+				m:    0,
+				plan: 0,
+				tags: []string{"tag1", "tag2"},
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -107,6 +129,7 @@ func TestService_CreateRun(t *testing.T) {
 				e:    "test",
 				m:    0,
 				plan: 0,
+				tags: []string{},
 				args: baseArgs{
 					err:    errors.New("error"),
 					isUsed: true,
@@ -129,13 +152,14 @@ func TestService_CreateRun(t *testing.T) {
 					tt.args.e,
 					tt.args.m,
 					tt.args.plan,
+					tt.args.tags,
 				).
 					Return(tt.want, tt.args.args.err)
 			}
 
 			s := NewService(f.client)
 
-			got, err := s.CreateRun(context.Background(), tt.args.pc, tt.args.t, tt.args.d, tt.args.e, tt.args.m, tt.args.plan)
+			got, err := s.CreateRun(context.Background(), tt.args.pc, tt.args.t, tt.args.d, tt.args.e, tt.args.m, tt.args.plan, tt.args.tags)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("CreateRun() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
- Introduced a new `--tags` flag to the `create` command for specifying tags associated with the test run.
- Updated the `CreateRun` method in the client and service layers to accept tags as a parameter.
- Modified relevant tests and mocks to accommodate the new tags functionality.
- Updated documentation to reflect the addition of the `--tags` option.