### PR TITLE
fix: add output flag to filter command for specifying output path

### DIFF
--- a/cmd/testops/filter/filter.go
+++ b/cmd/testops/filter/filter.go
@@ -77,5 +77,7 @@ func Command() *cobra.Command {
 		slog.Error("Error while marking flag as required", "error", err)
 	}
 
+	cmd.Flags().StringVarP(&output, outputFlag, "o", "", "output path for the filtered results")
+
 	return cmd
 }


### PR DESCRIPTION
- Introduced a new `--output` flag to the `filter` command to allow users to specify the output path for filtered results.
- Updated command functionality to support the new output option.