### PR TITLE
feat: enhance create run command with cloud and browser options

### DIFF
--- a/docs/command.md
+++ b/docs/command.md
@@ -20,7 +20,7 @@ cat qase.env | grep QASE_TESTOPS_RUN_ID | cut -d'=' -f2
 ## Example usage
 
 ```bash
-qasectl testops run create --project <project_code> --token <token> --title <title> --description <description> --environment <environment> --milestone <milestone> --plan <plan> --verbose
+qasectl testops run create --project <project_code> --token <token> --title <title> --description <description> --environment <environment> --milestone <milestone> --plan <plan> --cloud --browser <browser> --verbose
 ```
 
 The `create` command has the following options:
@@ -33,6 +33,8 @@ The `create` command has the following options:
 - `--milestone`, `-m`: The milestone of the test run. Optional.
 - `--plan`: The test plan of the test run. Optional.
 - `--tags`: The tags of the test run. Optional.
+- `--cloud`: Mark the test run as a cloud run. Optional. Must be used together with `--browser`.
+- `--browser`: The browser for the cloud run. Optional. Must be used together with `--cloud`. Allowed values: `chromium`, `firefox`, `webkit`.
 - `--output`, `-o`: The output path to save the test run ID. Optional. Default is `qase.env` in the current
   directory.
 - `--verbose`, `-v`: Enable verbose mode. Optional.
@@ -41,6 +43,12 @@ The following example shows how to create a test run in the project with the cod
 
 ```bash
 qasectl testops run create --project PROJ --token <token> --title "Test Run 1" --description "This is a test run" --environment "Production" --milestone "Milestone 1" --plan "Test Plan 1" --tags "tag1,tag2" --verbose
+```
+
+The following example shows how to create a cloud test run with a specific browser:
+
+```bash
+qasectl testops run create --project PROJ --token <token> --title "Cloud Test Run" --description "This is a cloud test run" --cloud --browser "chromium" --verbose
 ```
 
 # Complete a test run

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/google/uuid v1.6.0
 	github.com/magiconair/properties v1.8.7
-	github.com/qase-tms/qase-go/qase-api-client v1.1.2
-	github.com/qase-tms/qase-go/qase-api-v2-client v1.1.2
+	github.com/qase-tms/qase-go/qase-api-client v1.1.5
+	github.com/qase-tms/qase-go/qase-api-v2-client v1.1.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2
 	go.uber.org/mock v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,10 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/qase-tms/qase-go/qase-api-client v1.1.2 h1:7w3w8zGZZRShCoO+bNizpHwSna1MdcjgI9QgZLhvP1I=
-github.com/qase-tms/qase-go/qase-api-client v1.1.2/go.mod h1:5w7jTtz8r3ccc8axnK0Sq6Dx5JKJtJnaz8AuysTw7SA=
-github.com/qase-tms/qase-go/qase-api-v2-client v1.1.2 h1:YSUqrwnsGUIzDjsAzsXS2qB86TcxCiOeCLz9787ZPb0=
-github.com/qase-tms/qase-go/qase-api-v2-client v1.1.2/go.mod h1:qyIUXyT9ein6Ii2+IUW3R0eXWAJzVj44II05RRMR+wg=
+github.com/qase-tms/qase-go/qase-api-client v1.1.5 h1:9uJk4udv2gRE4PuoAf5eWHwBzqMGIN7JnDav4c1sqWo=
+github.com/qase-tms/qase-go/qase-api-client v1.1.5/go.mod h1:5w7jTtz8r3ccc8axnK0Sq6Dx5JKJtJnaz8AuysTw7SA=
+github.com/qase-tms/qase-go/qase-api-v2-client v1.1.3 h1:UK3O2HJUb9KydoYekkZFMM+pqmf3qEZHgohdgWWh5FU=
+github.com/qase-tms/qase-go/qase-api-v2-client v1.1.3/go.mod h1:qyIUXyT9ein6Ii2+IUW3R0eXWAJzVj44II05RRMR+wg=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/client/clientv1.go
+++ b/internal/client/clientv1.go
@@ -259,7 +259,7 @@ func (c *ClientV1) GetPlan(ctx context.Context, projectCode string, planID int64
 }
 
 // CreateRun creates a new run
-func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string) (int64, error) {
+func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string, isCloud bool, browser string) (int64, error) {
 	const op = "client.clientv1.createrun"
 	logger := slog.With("op", op)
 
@@ -289,6 +289,18 @@ func (c *ClientV1) CreateRun(ctx context.Context, projectCode, title string, des
 
 	if len(tags) > 0 {
 		m.SetTags(tags)
+	}
+
+	if isCloud {
+		m.SetIsCloud(true)
+	}
+
+	if browser != "" {
+		cloudConfig := apiV1Client.RunCreateCloudRunConfig{
+			Browser: &browser,
+		}
+
+		m.SetCloudRunConfig(cloudConfig)
 	}
 
 	logger.Debug("creating run", "projectCode", projectCode, "model", m)

--- a/internal/service/result/mocks/result.go
+++ b/internal/service/result/mocks/result.go
@@ -130,16 +130,16 @@ func (mr *MockrunServiceMockRecorder) CompleteRun(ctx, projectCode, runId any) *
 }
 
 // CreateRun mocks base method.
-func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e string, m, plan int64, tags []string) (int64, error) {
+func (m_2 *MockrunService) CreateRun(ctx context.Context, p, t, d, e string, m, plan int64, tags []string, isCloud bool, browser string) (int64, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "CreateRun", ctx, p, t, d, e, m, plan, tags)
+	ret := m_2.ctrl.Call(m_2, "CreateRun", ctx, p, t, d, e, m, plan, tags, isCloud, browser)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRun indicates an expected call of CreateRun.
-func (mr *MockrunServiceMockRecorder) CreateRun(ctx, p, t, d, e, m, plan, tags any) *gomock.Call {
+func (mr *MockrunServiceMockRecorder) CreateRun(ctx, p, t, d, e, m, plan, tags, isCloud, browser any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*MockrunService)(nil).CreateRun), ctx, p, t, d, e, m, plan, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*MockrunService)(nil).CreateRun), ctx, p, t, d, e, m, plan, tags, isCloud, browser)
 }

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -22,7 +22,7 @@ type Parser interface {
 
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type runService interface {
-	CreateRun(ctx context.Context, p, t string, d, e string, m, plan int64, tags []string) (int64, error)
+	CreateRun(ctx context.Context, p, t string, d, e string, m, plan int64, tags []string, isCloud bool, browser string) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 }
 
@@ -62,7 +62,7 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 	runID := p.RunID
 	isTestRunCreated := false
 	if runID == 0 {
-		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0, []string{})
+		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0, []string{}, false, "")
 		if err != nil {
 			return err
 		}

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -428,7 +428,18 @@ func TestService_Upload(t *testing.T) {
 			}
 
 			if tt.rArgs.isUsed {
-				f.rs.EXPECT().CreateRun(gomock.Any(), tt.args.p.Project, tt.args.p.Title, tt.args.p.Description, "", int64(0), int64(0), []string{}).Return(tt.rArgs.model, tt.rArgs.err)
+				f.rs.EXPECT().CreateRun(
+					gomock.Any(),
+					tt.args.p.Project,
+					tt.args.p.Title,
+					tt.args.p.Description,
+					"",         // envSlug
+					int64(0),   // mileID
+					int64(0),   // planID
+					[]string{}, // tags
+					false,      // isCloud
+					"",         // browser
+				).Return(tt.rArgs.model, tt.rArgs.err)
 			}
 
 			if tt.cArgs.isUsed {

--- a/internal/service/run/mocks/run.go
+++ b/internal/service/run/mocks/run.go
@@ -55,18 +55,18 @@ func (mr *MockclientMockRecorder) CompleteRun(ctx, projectCode, runId any) *gomo
 }
 
 // CreateRun mocks base method.
-func (m *Mockclient) CreateRun(ctx context.Context, projectCode, title, description, envSlug string, mileID, planID int64, tags []string) (int64, error) {
+func (m *Mockclient) CreateRun(ctx context.Context, projectCode, title, description, envSlug string, mileID, planID int64, tags []string, isCloud bool, browser string) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRun", ctx, projectCode, title, description, envSlug, mileID, planID, tags)
+	ret := m.ctrl.Call(m, "CreateRun", ctx, projectCode, title, description, envSlug, mileID, planID, tags, isCloud, browser)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRun indicates an expected call of CreateRun.
-func (mr *MockclientMockRecorder) CreateRun(ctx, projectCode, title, description, envSlug, mileID, planID, tags any) *gomock.Call {
+func (mr *MockclientMockRecorder) CreateRun(ctx, projectCode, title, description, envSlug, mileID, planID, tags, isCloud, browser any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*Mockclient)(nil).CreateRun), ctx, projectCode, title, description, envSlug, mileID, planID, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRun", reflect.TypeOf((*Mockclient)(nil).CreateRun), ctx, projectCode, title, description, envSlug, mileID, planID, tags, isCloud, browser)
 }
 
 // DeleteTestRun mocks base method.

--- a/internal/service/run/run.go
+++ b/internal/service/run/run.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+
 	"github.com/qase-tms/qasectl/internal/models/run"
 )
 
@@ -10,7 +11,7 @@ import (
 //
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 type client interface {
-	CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string) (int64, error)
+	CreateRun(ctx context.Context, projectCode, title string, description, envSlug string, mileID, planID int64, tags []string, isCloud bool, browser string) (int64, error)
 	CompleteRun(ctx context.Context, projectCode string, runId int64) error
 	GetTestRuns(ctx context.Context, projectCode string, start, end int64) ([]run.Run, error)
 	DeleteTestRun(ctx context.Context, projectCode string, id int64) error
@@ -27,8 +28,8 @@ func NewService(client client) *Service {
 }
 
 // CreateRun creates a new run
-func (s *Service) CreateRun(ctx context.Context, pc, t, d, e string, m, plan int64, tags []string) (int64, error) {
-	return s.client.CreateRun(ctx, pc, t, d, e, m, plan, tags)
+func (s *Service) CreateRun(ctx context.Context, pc, t, d, e string, m, plan int64, tags []string, isCloud bool, browser string) (int64, error) {
+	return s.client.CreateRun(ctx, pc, t, d, e, m, plan, tags, isCloud, browser)
 }
 
 // CompleteRun completes a run

--- a/internal/service/run/run_test.go
+++ b/internal/service/run/run_test.go
@@ -66,14 +66,16 @@ func TestService_CompleteRun(t *testing.T) {
 
 func TestService_CreateRun(t *testing.T) {
 	type args struct {
-		pc   string
-		t    string
-		d    string
-		e    string
-		m    int64
-		plan int64
-		tags []string
-		args baseArgs
+		pc      string
+		t       string
+		d       string
+		e       string
+		m       int64
+		plan    int64
+		tags    []string
+		isCloud bool
+		browser string
+		args    baseArgs
 	}
 	tests := []struct {
 		name       string
@@ -85,13 +87,15 @@ func TestService_CreateRun(t *testing.T) {
 		{
 			name: "success",
 			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    0,
-				plan: 0,
-				tags: []string{},
+				pc:      "test",
+				t:       "test",
+				d:       "test",
+				e:       "test",
+				m:       0,
+				plan:    0,
+				tags:    []string{},
+				isCloud: false,
+				browser: "",
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -104,13 +108,36 @@ func TestService_CreateRun(t *testing.T) {
 		{
 			name: "success with tags",
 			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    0,
-				plan: 0,
-				tags: []string{"tag1", "tag2"},
+				pc:      "test",
+				t:       "test",
+				d:       "test",
+				e:       "test",
+				m:       0,
+				plan:    0,
+				tags:    []string{"tag1", "tag2"},
+				isCloud: false,
+				browser: "",
+				args: baseArgs{
+					err:    nil,
+					isUsed: true,
+				},
+			},
+			want:       1,
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "success with cloud and browser",
+			args: args{
+				pc:      "test",
+				t:       "test",
+				d:       "test",
+				e:       "test",
+				m:       0,
+				plan:    0,
+				tags:    []string{},
+				isCloud: true,
+				browser: "chromium",
 				args: baseArgs{
 					err:    nil,
 					isUsed: true,
@@ -123,13 +150,15 @@ func TestService_CreateRun(t *testing.T) {
 		{
 			name: "failed to create run",
 			args: args{
-				pc:   "test",
-				t:    "test",
-				d:    "test",
-				e:    "test",
-				m:    0,
-				plan: 0,
-				tags: []string{},
+				pc:      "test",
+				t:       "test",
+				d:       "test",
+				e:       "test",
+				m:       0,
+				plan:    0,
+				tags:    []string{},
+				isCloud: false,
+				browser: "",
 				args: baseArgs{
 					err:    errors.New("error"),
 					isUsed: true,
@@ -145,7 +174,8 @@ func TestService_CreateRun(t *testing.T) {
 			f := newFixture(t)
 
 			if tt.args.args.isUsed {
-				f.client.EXPECT().CreateRun(gomock.Any(),
+				f.client.EXPECT().CreateRun(
+					gomock.Any(),
 					tt.args.pc,
 					tt.args.t,
 					tt.args.d,
@@ -153,13 +183,26 @@ func TestService_CreateRun(t *testing.T) {
 					tt.args.m,
 					tt.args.plan,
 					tt.args.tags,
+					tt.args.isCloud,
+					tt.args.browser,
 				).
 					Return(tt.want, tt.args.args.err)
 			}
 
 			s := NewService(f.client)
 
-			got, err := s.CreateRun(context.Background(), tt.args.pc, tt.args.t, tt.args.d, tt.args.e, tt.args.m, tt.args.plan, tt.args.tags)
+			got, err := s.CreateRun(
+				context.Background(),
+				tt.args.pc,
+				tt.args.t,
+				tt.args.d,
+				tt.args.e,
+				tt.args.m,
+				tt.args.plan,
+				tt.args.tags,
+				tt.args.isCloud,
+				tt.args.browser,
+			)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("CreateRun() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
- Added `--cloud` and `--browser` flags to the `create` command for specifying cloud test runs and the browser to use.
- Updated the `CreateRun` method in the client and service layers to accept new parameters for cloud configuration.
- Modified relevant tests and mocks to accommodate the new functionality.
- Updated documentation to reflect the addition of the new command options and usage examples.