### PR TITLE
feat: add skip params functionality to upload command

### DIFF
--- a/cmd/testops/result/upload/upload.go
+++ b/cmd/testops/result/upload/upload.go
@@ -24,6 +24,7 @@ const (
 	titleFlag       = "title"
 	descriptionFlag = "description"
 	statusFlag      = "replace-statuses"
+	skipParamsFlag  = "skip-params"
 )
 
 // Command returns a new cobra command for upload
@@ -38,6 +39,7 @@ func Command() *cobra.Command {
 		batch       int64
 		suite       string
 		status      string
+		skipParams  bool
 	)
 
 	cmd := &cobra.Command{
@@ -91,6 +93,7 @@ func Command() *cobra.Command {
 				Project:     project,
 				Suite:       suite,
 				Statuses:    statuses,
+				SkipParams:  skipParams,
 			}
 
 			err := s.Upload(cmd.Context(), param)
@@ -126,6 +129,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Int64VarP(&batch, "batch", "b", 200, "Batch size for uploading results")
 	cmd.Flags().StringVarP(&suite, "suite", "s", "", "Root suite for the results")
 	cmd.Flags().StringVar(&status, statusFlag, "", "Replace statuses of the results. Pass '{\"Passed\": \"Failed\"}' to replace all passed results with failed")
+	cmd.Flags().BoolVar(&skipParams, skipParamsFlag, false, "Skip parameters for the results")
 
 	return cmd
 }

--- a/docs/command.md
+++ b/docs/command.md
@@ -139,6 +139,7 @@ The `upload` command has the following options:
 - `--batch`: The batch number of the test results. Optional. Default is 200.
 - `--suite`, `-s`: The suite name of the test results. Optional.
 - `--replace-statuses`, `-r`: The statuses to replace. Optional. Pass like '{\"Passed\": \"Failed\"}' to replace all passed results with failed. Note: Use slugs of statuses.
+- `--skip-params`: Skip parameters for the results. Optional.
 - `--verbose`, `-v`: Enable verbose mode. Optional.
 
 The following example shows how to upload test results in the JUnit format for a test run with the ID `1` in the project

--- a/internal/service/result/fixture_test.go
+++ b/internal/service/result/fixture_test.go
@@ -1,10 +1,11 @@
 package result
 
 import (
+	"testing"
+
 	models "github.com/qase-tms/qasectl/internal/models/result"
 	"github.com/qase-tms/qasectl/internal/service/result/mocks"
 	"go.uber.org/mock/gomock"
-	"testing"
 )
 
 type fixture struct {
@@ -42,14 +43,55 @@ func prepareModels() []models.Result {
 			Attachments: []models.Attachment{},
 			Steps:       []models.Step{},
 			StepType:    "text",
-			Params:      make(map[string]string),
-			Relations:   models.Relation{},
-			Muted:       false,
-			Message:     nil,
+			Params: map[string]string{
+				"browser": "chrome",
+				"version": "1.0.0",
+			},
+			Relations: models.Relation{
+				Suite: models.Suite{
+					Data: []models.SuiteData{},
+				},
+			},
+			Muted:   false,
+			Message: nil,
 		},
 		{
 			ID:        nil,
 			Title:     "Test 2",
+			Signature: nil,
+			TestOpsID: nil,
+			Execution: models.Execution{
+				StartTime:  nil,
+				EndTime:    nil,
+				Status:     "failed",
+				Duration:   nil,
+				StackTrace: nil,
+				Thread:     nil,
+			},
+			Fields:      make(map[string]string),
+			Attachments: []models.Attachment{},
+			Steps:       []models.Step{},
+			StepType:    "text",
+			Params: map[string]string{
+				"browser": "firefox",
+				"version": "1.0.0",
+			},
+			Relations: models.Relation{
+				Suite: models.Suite{
+					Data: []models.SuiteData{},
+				},
+			},
+			Muted:   false,
+			Message: nil,
+		},
+	}
+}
+
+func prepareModelsWithEmptyParams() []models.Result {
+	return []models.Result{
+		{
+			ID:        nil,
+			Title:     "Test with Empty Params",
 			Signature: nil,
 			TestOpsID: nil,
 			Execution: models.Execution{
@@ -64,10 +106,14 @@ func prepareModels() []models.Result {
 			Attachments: []models.Attachment{},
 			Steps:       []models.Step{},
 			StepType:    "text",
-			Params:      make(map[string]string),
-			Relations:   models.Relation{},
-			Muted:       false,
-			Message:     nil,
+			Params:      nil, // Empty params for SkipParams testing
+			Relations: models.Relation{
+				Suite: models.Suite{
+					Data: []models.SuiteData{},
+				},
+			},
+			Muted:   false,
+			Message: nil,
 		},
 	}
 }

--- a/internal/service/result/models.go
+++ b/internal/service/result/models.go
@@ -8,4 +8,5 @@ type UploadParams struct {
 	Project     string
 	Suite       string
 	Statuses    map[string]string
+	SkipParams  bool
 }

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -90,6 +90,12 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 		}
 	}
 
+	if p.SkipParams {
+		for i := range results {
+			results[i].Params = nil
+		}
+	}
+
 	err = s.uploadResults(ctx, p.Project, p.Batch, runID, results)
 	if err != nil {
 		return fmt.Errorf("failed to upload results: %w", err)

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -418,6 +418,280 @@ func TestService_Upload(t *testing.T) {
 			wantErr:    false,
 			errMessage: "",
 		},
+		{
+			name: "success with skip params",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       1,
+					Batch:       20,
+					Suite:       "",
+					SkipParams:  true,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: []models.Result{
+					{
+						Execution: models.Execution{
+							Status: "passed",
+						},
+						Params: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+				},
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: false,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: false,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "success with suite and skip params",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       0,
+					Batch:       20,
+					Suite:       "test-suite",
+					SkipParams:  true,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: []models.Result{
+					{
+						Execution: models.Execution{
+							Status: "passed",
+						},
+						Params: map[string]string{
+							"key1": "value1",
+						},
+						Relations: models.Relation{
+							Suite: models.Suite{
+								Data: []models.SuiteData{},
+							},
+						},
+					},
+				},
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: true,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: true,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "success with complex status mapping and skip params",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       0,
+					Batch:       20,
+					Suite:       "complex-suite",
+					Statuses: map[string]string{
+						"passed":  "passed",
+						"failed":  "failed",
+						"skipped": "skipped",
+						"blocked": "blocked",
+					},
+					SkipParams: true,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: []models.Result{
+					{
+						Execution: models.Execution{
+							Status: "passed",
+						},
+						Params: map[string]string{
+							"key1": "value1",
+						},
+						Relations: models.Relation{
+							Suite: models.Suite{
+								Data: []models.SuiteData{},
+							},
+						},
+					},
+					{
+						Execution: models.Execution{
+							Status: "failed",
+						},
+						Params: map[string]string{
+							"key2": "value2",
+						},
+						Relations: models.Relation{
+							Suite: models.Suite{
+								Data: []models.SuiteData{},
+							},
+						},
+					},
+					{
+						Execution: models.Execution{
+							Status: "skipped",
+						},
+						Params: map[string]string{
+							"key3": "value3",
+						},
+						Relations: models.Relation{
+							Suite: models.Suite{
+								Data: []models.SuiteData{},
+							},
+						},
+					},
+				},
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: true,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: true,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "verify skip params functionality",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       1,
+					Batch:       20,
+					Suite:       "",
+					SkipParams:  true,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: prepareModels(), // Models with params
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: false,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: false,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "verify params are preserved when skip params is false",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       1,
+					Batch:       20,
+					Suite:       "",
+					SkipParams:  false,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: prepareModels(), // Models with params
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: false,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: false,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
+		{
+			name: "skip params with already empty params",
+			args: args{
+				p: UploadParams{
+					Project:     "project",
+					Title:       "title",
+					Description: "description",
+					RunID:       1,
+					Batch:       20,
+					Suite:       "",
+					SkipParams:  true,
+				},
+				err:    nil,
+				isUsed: true,
+				count:  1,
+				runID:  1,
+			},
+			pArgs: pArgs{
+				models: prepareModelsWithEmptyParams(), // Models without params
+				err:    nil,
+				isUsed: true,
+			},
+			rArgs: rArgs{
+				model:  1,
+				err:    nil,
+				isUsed: false,
+			},
+			cArgs: cArgs{
+				err:    nil,
+				isUsed: false,
+			},
+			wantErr:    false,
+			errMessage: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Introduced a new `--skip-params` flag to the `upload` command to allow users to skip parameters during the upload process.
- Updated the `UploadParams` structure to include the `SkipParams` field.
- Enhanced the upload logic to clear parameters when the `skipParams` option is enabled.
- Added unit tests to verify the functionality of skipping parameters in various scenarios.
- Updated documentation to reflect the new command option and its usage.