### PR TITLE
fix: correct duration calculation in XCTest parser

### DIFF
--- a/internal/parsers/xctest/xctest.go
+++ b/internal/parsers/xctest/xctest.go
@@ -288,7 +288,7 @@ func (p *Parser) getXCTestsFromSubtest(s Subtests, suites []string) []XCTest {
 				Action:    act,
 				Suites:    make([]string, 0),
 				Signature: v.IdentifierURL.Value,
-				Duration:  d,
+				Duration:  d * 1000,
 			}
 
 			if len(suites) > 0 {


### PR DESCRIPTION
- Updated the duration value in the getXCTestsFromSubtest method to multiply by 1000, ensuring accurate representation of time in milliseconds.
- This change enhances the consistency of time handling across the XCTest parser, aligning with recent updates for improved accuracy.