### PR TITLE
fix: strip UTF-8 BOM prefix in JSON parsers

### DIFF
--- a/internal/parsers/allure/allure.go
+++ b/internal/parsers/allure/allure.go
@@ -1,6 +1,7 @@
 package allure
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -111,6 +112,8 @@ func (p *Parser) parseFile(file string) (models.Result, error) {
 	if err != nil {
 		return models.Result{}, fmt.Errorf("failed to read file: %w", err)
 	}
+
+	byteValue = bytes.TrimPrefix(byteValue, []byte("\xef\xbb\xbf"))
 
 	var test Test
 	err = json.Unmarshal(byteValue, &test)

--- a/internal/parsers/allure/allure_test.go
+++ b/internal/parsers/allure/allure_test.go
@@ -1,11 +1,49 @@
 package allure
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	models "github.com/qase-tms/qasectl/internal/models/result"
 )
+
+func TestParseFile_WithBOM(t *testing.T) {
+	content := []byte("\xef\xbb\xbf" + `{
+		"uuid": "abc-123",
+		"name": "BOM Test",
+		"start": 1000,
+		"stop": 2000,
+		"status": "passed",
+		"statusDetails": {},
+		"steps": [],
+		"attachments": [],
+		"links": [],
+		"labels": []
+	}`)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bom-result.json")
+
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	parser := NewParser(filePath)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Title != "BOM Test" {
+		t.Errorf("expected title 'BOM Test', got '%s'", results[0].Title)
+	}
+}
 
 func TestParser_extractTestOpsID(t *testing.T) {
 	parser := &Parser{}

--- a/internal/parsers/qase/qase.go
+++ b/internal/parsers/qase/qase.go
@@ -1,6 +1,7 @@
 package qase
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	models "github.com/qase-tms/qasectl/internal/models/result"
@@ -82,6 +83,8 @@ func (p *Parser) parseFile(path string) (models.Result, error) {
 	if err != nil {
 		return models.Result{}, fmt.Errorf("failed to read file: %w", err)
 	}
+
+	byteValue = bytes.TrimPrefix(byteValue, []byte("\xef\xbb\xbf"))
 
 	var result models.Result
 	err = json.Unmarshal(byteValue, &result)

--- a/internal/parsers/qase/qase_test.go
+++ b/internal/parsers/qase/qase_test.go
@@ -1,0 +1,69 @@
+package qase
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFile_WithBOM(t *testing.T) {
+	content := []byte("\xef\xbb\xbf" + `{
+		"title": "BOM Test",
+		"execution": {
+			"status": "passed",
+			"duration": 100
+		}
+	}`)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bom_test.json")
+
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	parser := NewParser(filePath)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Title != "BOM Test" {
+		t.Errorf("expected title 'BOM Test', got '%s'", results[0].Title)
+	}
+}
+
+func TestParseFile_WithoutBOM(t *testing.T) {
+	content := []byte(`{
+		"title": "No BOM Test",
+		"execution": {
+			"status": "passed",
+			"duration": 100
+		}
+	}`)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "no_bom_test.json")
+
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	parser := NewParser(filePath)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Title != "No BOM Test" {
+		t.Errorf("expected title 'No BOM Test', got '%s'", results[0].Title)
+	}
+}


### PR DESCRIPTION
## Summary
- JSON files generated by some tools (e.g. NUnit on .NET) may contain a UTF-8 BOM (`0xEF 0xBB 0xBF`) at the beginning, causing `json.Unmarshal` to fail with `invalid character 'ï' looking for beginning of value`
- Added `bytes.TrimPrefix` to strip BOM before unmarshalling in both `qase` and `allure` parsers
- Added tests for BOM handling in both parsers

## Test plan
- [x] `go test ./internal/parsers/...` — all tests pass
- [x] Verify with a real NUnit-generated JSON file containing BOM