### PR TITLE
Quality & safety: bug fixes, refactoring, tests, and performance

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestRootCommand_HasExpectedSubcommands(t *testing.T) {
+	subcommands := make(map[string]bool)
+	for _, cmd := range rootCmd.Commands() {
+		subcommands[cmd.Name()] = true
+	}
+
+	expected := []string{"testops", "version"}
+	for _, name := range expected {
+		if !subcommands[name] {
+			t.Errorf("rootCmd missing expected subcommand %q", name)
+		}
+	}
+}
+
+func TestRootCommand_VerboseFlag(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("verbose")
+	if flag == nil {
+		t.Fatal("verbose flag not registered on rootCmd")
+	}
+
+	if flag.DefValue != "false" {
+		t.Errorf("verbose flag default = %q, want %q", flag.DefValue, "false")
+	}
+
+	if flag.Shorthand != "v" {
+		t.Errorf("verbose flag shorthand = %q, want %q", flag.Shorthand, "v")
+	}
+}
+
+func TestTestopsCommand_SubcommandRegistration(t *testing.T) {
+	testopsCmd, _, err := rootCmd.Find([]string{"testops"})
+	if err != nil {
+		t.Fatalf("failed to find testops command: %v", err)
+	}
+
+	subcommands := make(map[string]bool)
+	for _, cmd := range testopsCmd.Commands() {
+		subcommands[cmd.Name()] = true
+	}
+
+	expected := []string{"run", "result", "env", "milestone", "filter", "field"}
+	for _, name := range expected {
+		if !subcommands[name] {
+			t.Errorf("testops missing expected subcommand %q", name)
+		}
+	}
+}
+
+func TestTestopsCommand_PersistentFlags(t *testing.T) {
+	testopsCmd, _, err := rootCmd.Find([]string{"testops"})
+	if err != nil {
+		t.Fatalf("failed to find testops command: %v", err)
+	}
+
+	if testopsCmd.PersistentFlags().Lookup("token") == nil {
+		t.Error("testops missing persistent flag 'token'")
+	}
+
+	if testopsCmd.PersistentFlags().Lookup("project") == nil {
+		t.Error("testops missing persistent flag 'project'")
+	}
+}
+
+func TestTestopsCommand_RequiredFlags(t *testing.T) {
+	testopsCmd, _, err := rootCmd.Find([]string{"testops"})
+	if err != nil {
+		t.Fatalf("failed to find testops command: %v", err)
+	}
+
+	tokenFlag := testopsCmd.PersistentFlags().Lookup("token")
+	if tokenFlag == nil {
+		t.Fatal("testops missing 'token' flag")
+	}
+	if _, ok := tokenFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]; !ok {
+		t.Error("token flag is not marked as required")
+	}
+
+	projectFlag := testopsCmd.PersistentFlags().Lookup("project")
+	if projectFlag == nil {
+		t.Fatal("testops missing 'project' flag")
+	}
+	if _, ok := projectFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]; !ok {
+		t.Error("project flag is not marked as required")
+	}
+}

--- a/cmd/testops/env/create/create.go
+++ b/cmd/testops/env/create/create.go
@@ -73,13 +73,13 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&title, titleFlag, "", "title of the environment")
 	err := cmd.MarkFlagRequired(titleFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark title flag required", "error", err)
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the environment")
 	cmd.Flags().StringVarP(&slug, slugFlag, "s", "", "slug of the environment, (string without spaces)")
 	err = cmd.MarkFlagRequired(slugFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark slug flag required", "error", err)
 	}
 	cmd.Flags().StringVar(&host, hostFlag, "", "host of the environment")
 	cmd.Flags().StringVarP(&output, outputFlag, "o", "", "output path for the environment ID")

--- a/cmd/testops/milestone/create/create.go
+++ b/cmd/testops/milestone/create/create.go
@@ -82,7 +82,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&title, titleFlag, "", "title of the milestone")
 	err := cmd.MarkFlagRequired(titleFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark title flag required", "error", err)
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the milestone")
 	cmd.Flags().StringVarP(&status, statusFlag, "s", "", "status of the milestone. Allowed values: active, completed")

--- a/cmd/testops/run/complete/complete.go
+++ b/cmd/testops/run/complete/complete.go
@@ -2,6 +2,8 @@ package complete
 
 import (
 	"fmt"
+	"log/slog"
+
 	"github.com/qase-tms/qasectl/cmd/flags"
 	"github.com/qase-tms/qasectl/internal/client"
 	"github.com/qase-tms/qasectl/internal/service/run"
@@ -43,7 +45,7 @@ func Command() *cobra.Command {
 	cmd.Flags().Int64Var(&runID, idFlag, 0, "ID of the test run")
 	err := cmd.MarkFlagRequired(idFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark id flag required", "error", err)
 	}
 
 	return cmd

--- a/cmd/testops/run/create/create.go
+++ b/cmd/testops/run/create/create.go
@@ -90,7 +90,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&title, titleFlag, "", "", "title of the test run")
 	err := cmd.MarkFlagRequired(titleFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark title flag required", "error", err)
 	}
 	cmd.Flags().StringVarP(&description, descriptionFlag, "d", "", "description of the test run")
 	cmd.Flags().StringVarP(&environment, environmentFlag, "e", "", "slug of environment of the test run")

--- a/cmd/testops/testops.go
+++ b/cmd/testops/testops.go
@@ -1,7 +1,7 @@
 package testops
 
 import (
-	"fmt"
+	"log/slog"
 
 	"github.com/qase-tms/qasectl/cmd/flags"
 	"github.com/qase-tms/qasectl/cmd/testops/env"
@@ -30,21 +30,21 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().StringP(tokenFlag, "t", "", "token for Qase API access")
 	err := viper.BindPFlag(flags.TokenFlag, cmd.PersistentFlags().Lookup(tokenFlag))
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to bind token flag", "error", err)
 	}
 	err = cmd.MarkPersistentFlagRequired(tokenFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark token flag required", "error", err)
 	}
 
 	cmd.PersistentFlags().StringP(projectFlag, "p", "", "project code for Qase API access")
 	err = viper.BindPFlag(flags.ProjectFlag, cmd.PersistentFlags().Lookup(projectFlag))
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to bind project flag", "error", err)
 	}
 	err = cmd.MarkPersistentFlagRequired(projectFlag)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("failed to mark project flag required", "error", err)
 	}
 
 	cmd.AddCommand(run.Command())

--- a/internal/client/clientv1.go
+++ b/internal/client/clientv1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	apiV1Client "github.com/qase-tms/qase-go/qase-api-client"
@@ -17,9 +18,22 @@ const (
 	defaultLimit = 50
 )
 
+// paginationLimit returns the configured pagination limit.
+// It reads from the QASE_TESTOPS_PAGINATION_LIMIT environment variable.
+// Falls back to defaultLimit (50) when not set or invalid.
+func paginationLimit() int32 {
+	if s := os.Getenv("QASE_TESTOPS_PAGINATION_LIMIT"); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 32); err == nil && v > 0 {
+			return int32(v)
+		}
+	}
+	return defaultLimit
+}
+
 // paginate fetches all pages from a paginated API endpoint.
 // fetchPage receives an offset and returns (converted entities, total/filtered count, error).
 func paginate[T any](fetchPage func(offset int32) ([]T, int32, error)) ([]T, error) {
+	limit := paginationLimit()
 	var result []T
 	var offset int32
 	for {
@@ -28,7 +42,7 @@ func paginate[T any](fetchPage func(offset int32) ([]T, int32, error)) ([]T, err
 			return nil, err
 		}
 		result = append(result, items...)
-		offset += defaultLimit
+		offset += limit
 		if offset >= total {
 			break
 		}
@@ -147,7 +161,7 @@ func (c *ClientV1) GetEnvironments(ctx context.Context, projectCode string) ([]r
 	environments, err := paginate(func(offset int32) ([]run.Environment, int32, error) {
 		resp, r, err := client.EnvironmentsAPI.
 			GetEnvironments(ctx, projectCode).
-			Limit(defaultLimit).
+			Limit(paginationLimit()).
 			Offset(offset).
 			Execute()
 		if err != nil {
@@ -216,7 +230,7 @@ func (c *ClientV1) GetPlans(ctx context.Context, projectCode string) ([]run.Plan
 	plans, err := paginate(func(offset int32) ([]run.Plan, int32, error) {
 		resp, r, err := client.PlansAPI.
 			GetPlans(ctx, projectCode).
-			Limit(defaultLimit).
+			Limit(paginationLimit()).
 			Offset(offset).
 			Execute()
 		if err != nil {
@@ -403,7 +417,7 @@ func (c *ClientV1) GetTestRuns(ctx context.Context, projectCode string, start, e
 	testRuns, err := paginate(func(offset int32) ([]run.Run, int32, error) {
 		req := client.RunsAPI.
 			GetRuns(ctx, projectCode).
-			Limit(defaultLimit).
+			Limit(paginationLimit()).
 			Offset(offset)
 
 		if start != 0 {
@@ -468,7 +482,7 @@ func (c *ClientV1) GetCustomFields(ctx context.Context) ([]custom.CustomField, e
 	customFields, err := paginate(func(offset int32) ([]custom.CustomField, int32, error) {
 		resp, r, err := client.CustomFieldsAPI.
 			GetCustomFields(ctx).
-			Limit(defaultLimit).
+			Limit(paginationLimit()).
 			Offset(offset).
 			Execute()
 		if err != nil {

--- a/internal/client/clientv1.go
+++ b/internal/client/clientv1.go
@@ -17,6 +17,25 @@ const (
 	defaultLimit = 50
 )
 
+// paginate fetches all pages from a paginated API endpoint.
+// fetchPage receives an offset and returns (converted entities, total/filtered count, error).
+func paginate[T any](fetchPage func(offset int32) ([]T, int32, error)) ([]T, error) {
+	var result []T
+	var offset int32
+	for {
+		items, total, err := fetchPage(offset)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, items...)
+		offset += defaultLimit
+		if offset >= total {
+			break
+		}
+	}
+	return result, nil
+}
+
 // ClientV1 is a client for Qase API v1
 type ClientV1 struct {
 	// token is a token for Qase API
@@ -125,33 +144,28 @@ func (c *ClientV1) GetEnvironments(ctx context.Context, projectCode string) ([]r
 
 	ctx, client := c.getApiV1Client(ctx)
 
-	environments := make([]run.Environment, 0)
-
-	var offset int32 = 0
-	for {
+	environments, err := paginate(func(offset int32) ([]run.Environment, int32, error) {
 		resp, r, err := client.EnvironmentsAPI.
 			GetEnvironments(ctx, projectCode).
 			Limit(defaultLimit).
 			Offset(offset).
 			Execute()
-
 		if err != nil {
-			return nil, NewQaseApiError(err.Error(), extractBody(r))
+			return nil, 0, NewQaseApiError(err.Error(), extractBody(r))
 		}
 
+		envs := make([]run.Environment, 0, len(resp.Result.Entities))
 		for _, env := range resp.Result.Entities {
-			environments = append(environments, run.Environment{
+			envs = append(envs, run.Environment{
 				Title: env.GetTitle(),
 				ID:    env.GetId(),
 				Slug:  env.GetSlug(),
 			})
 		}
-
-		if resp.Result.GetTotal() <= offset {
-			break
-		} else {
-			offset += defaultLimit
-		}
+		return envs, resp.Result.GetTotal(), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	logger.Debug("got environments", "environments", environments)
@@ -199,32 +213,27 @@ func (c *ClientV1) GetPlans(ctx context.Context, projectCode string) ([]run.Plan
 
 	ctx, client := c.getApiV1Client(ctx)
 
-	plans := make([]run.Plan, 0)
-
-	var offset int32 = 0
-	for {
+	plans, err := paginate(func(offset int32) ([]run.Plan, int32, error) {
 		resp, r, err := client.PlansAPI.
 			GetPlans(ctx, projectCode).
 			Limit(defaultLimit).
 			Offset(offset).
 			Execute()
-
 		if err != nil {
-			return nil, NewQaseApiError(err.Error(), extractBody(r))
+			return nil, 0, NewQaseApiError(err.Error(), extractBody(r))
 		}
 
+		p := make([]run.Plan, 0, len(resp.Result.Entities))
 		for _, plan := range resp.Result.Entities {
-			plans = append(plans, run.Plan{
+			p = append(p, run.Plan{
 				Title: plan.GetTitle(),
 				ID:    plan.GetId(),
 			})
 		}
-
-		if resp.Result.GetTotal() <= offset {
-			break
-		} else {
-			offset += defaultLimit
-		}
+		return p, resp.Result.GetTotal(), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	logger.Debug("got plans", "plans", plans)
@@ -391,10 +400,7 @@ func (c *ClientV1) GetTestRuns(ctx context.Context, projectCode string, start, e
 
 	ctx, client := c.getApiV1Client(ctx)
 
-	testRuns := make([]run.Run, 0)
-
-	var offset int32 = 0
-	for {
+	testRuns, err := paginate(func(offset int32) ([]run.Run, int32, error) {
 		req := client.RunsAPI.
 			GetRuns(ctx, projectCode).
 			Limit(defaultLimit).
@@ -409,22 +415,20 @@ func (c *ClientV1) GetTestRuns(ctx context.Context, projectCode string, start, e
 		}
 
 		resp, r, err := req.Execute()
-
 		if err != nil {
-			return nil, NewQaseApiError(err.Error(), extractBody(r))
+			return nil, 0, NewQaseApiError(err.Error(), extractBody(r))
 		}
 
+		runs := make([]run.Run, 0, len(resp.Result.Entities))
 		for _, testRun := range resp.Result.Entities {
-			testRuns = append(testRuns, run.Run{
+			runs = append(runs, run.Run{
 				ID: testRun.GetId(),
 			})
 		}
-
-		if resp.Result.GetFiltered() <= offset {
-			break
-		} else {
-			offset += defaultLimit
-		}
+		return runs, resp.Result.GetFiltered(), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	logger.Debug("got test runs", "testRuns", testRuns)
@@ -461,32 +465,27 @@ func (c *ClientV1) GetCustomFields(ctx context.Context) ([]custom.CustomField, e
 
 	ctx, client := c.getApiV1Client(ctx)
 
-	customFields := make([]custom.CustomField, 0)
-
-	var offset int32 = 0
-	for {
+	customFields, err := paginate(func(offset int32) ([]custom.CustomField, int32, error) {
 		resp, r, err := client.CustomFieldsAPI.
 			GetCustomFields(ctx).
 			Limit(defaultLimit).
 			Offset(offset).
 			Execute()
-
 		if err != nil {
-			return nil, NewQaseApiError(err.Error(), extractBody(r))
+			return nil, 0, NewQaseApiError(err.Error(), extractBody(r))
 		}
 
+		fields := make([]custom.CustomField, 0, len(resp.Result.Entities))
 		for _, field := range resp.Result.Entities {
-			customFields = append(customFields, custom.CustomField{
+			fields = append(fields, custom.CustomField{
 				ID:    field.GetId(),
 				Title: field.GetTitle(),
 			})
 		}
-
-		if resp.Result.GetTotal() <= offset {
-			break
-		} else {
-			offset += defaultLimit
-		}
+		return fields, resp.Result.GetTotal(), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	logger.Debug("got custom fields", "customFields", customFields)

--- a/internal/client/clientv1_test.go
+++ b/internal/client/clientv1_test.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestPaginate(t *testing.T) {
+	tests := []struct {
+		name  string
+		pages map[int32]struct {
+			items []string
+			total int32
+			err   error
+		}
+		wantItems  []string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "single page",
+			pages: map[int32]struct {
+				items []string
+				total int32
+				err   error
+			}{
+				0: {items: []string{"a", "b", "c"}, total: 3},
+			},
+			wantItems: []string{"a", "b", "c"},
+		},
+		{
+			name: "multiple pages",
+			pages: map[int32]struct {
+				items []string
+				total int32
+				err   error
+			}{
+				0:   {items: makeStrings(int(defaultLimit)), total: 120},
+				50:  {items: makeStrings(int(defaultLimit)), total: 120},
+				100: {items: makeStrings(20), total: 120},
+			},
+			wantItems: makeStrings(int(defaultLimit)*2 + 20),
+		},
+		{
+			name: "empty result",
+			pages: map[int32]struct {
+				items []string
+				total int32
+				err   error
+			}{
+				0: {items: []string{}, total: 0},
+			},
+			wantItems: nil,
+		},
+		{
+			name: "error on first page",
+			pages: map[int32]struct {
+				items []string
+				total int32
+				err   error
+			}{
+				0: {err: errors.New("api error")},
+			},
+			wantErr:    true,
+			wantErrMsg: "api error",
+		},
+		{
+			name: "filtered count (GetTestRuns pattern)",
+			pages: map[int32]struct {
+				items []string
+				total int32
+				err   error
+			}{
+				0:  {items: makeStrings(int(defaultLimit)), total: 80},
+				50: {items: makeStrings(30), total: 80},
+			},
+			wantItems: makeStrings(int(defaultLimit) + 30),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := paginate(func(offset int32) ([]string, int32, error) {
+				page, ok := tt.pages[offset]
+				if !ok {
+					t.Fatalf("unexpected offset %d", offset)
+				}
+				return page.items, page.total, page.err
+			})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if err.Error() != tt.wantErrMsg {
+					t.Errorf("error = %q, want %q", err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.wantItems) {
+				t.Errorf("got %d items, want %d", len(got), len(tt.wantItems))
+			}
+		})
+	}
+}
+
+// makeStrings creates n sequential string items for testing
+func makeStrings(n int) []string {
+	s := make([]string, n)
+	for i := 0; i < n; i++ {
+		s[i] = fmt.Sprintf("item-%d", i)
+	}
+	return s
+}

--- a/internal/client/clientv1_test.go
+++ b/internal/client/clientv1_test.go
@@ -110,6 +110,59 @@ func TestPaginate(t *testing.T) {
 	}
 }
 
+func TestPaginationLimit_Default(t *testing.T) {
+	got := paginationLimit()
+	if got != defaultLimit {
+		t.Errorf("paginationLimit() = %d, want %d", got, defaultLimit)
+	}
+}
+
+func TestPaginationLimit_Custom(t *testing.T) {
+	t.Setenv("QASE_TESTOPS_PAGINATION_LIMIT", "100")
+	got := paginationLimit()
+	if got != 100 {
+		t.Errorf("paginationLimit() = %d, want 100", got)
+	}
+}
+
+func TestPaginationLimit_InvalidValue(t *testing.T) {
+	t.Setenv("QASE_TESTOPS_PAGINATION_LIMIT", "0")
+	got := paginationLimit()
+	if got != defaultLimit {
+		t.Errorf("paginationLimit() with 0 = %d, want %d (default)", got, defaultLimit)
+	}
+}
+
+func TestPaginate_CustomLimit(t *testing.T) {
+	t.Setenv("QASE_TESTOPS_PAGINATION_LIMIT", "10")
+
+	callCount := 0
+	got, err := paginate(func(offset int32) ([]string, int32, error) {
+		callCount++
+		expectedOffset := int32((callCount - 1) * 10)
+		if offset != expectedOffset {
+			t.Errorf("call %d: offset = %d, want %d", callCount, offset, expectedOffset)
+		}
+		if callCount == 1 {
+			return makeStrings(10), 25, nil
+		}
+		if callCount == 2 {
+			return makeStrings(10), 25, nil
+		}
+		return makeStrings(5), 25, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 25 {
+		t.Errorf("got %d items, want 25", len(got))
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 pages with limit=10, got %d calls", callCount)
+	}
+}
+
 // makeStrings creates n sequential string items for testing
 func makeStrings(n int) []string {
 	s := make([]string, n)

--- a/internal/client/converterv1.go
+++ b/internal/client/converterv1.go
@@ -116,6 +116,7 @@ func (c *ClientV1) convertAttachments(ctx context.Context, projectCode string, a
 			}
 			continue
 		}
+		defer file.Close()
 
 		hash, err := c.uploadAttachment(ctx, projectCode, []*os.File{file})
 		if err != nil {

--- a/internal/parsers/allure/allure_test.go
+++ b/internal/parsers/allure/allure_test.go
@@ -121,6 +121,72 @@ func TestParser_convertTest_LayerField(t *testing.T) {
 	}
 }
 
+func TestParser_parseFile_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty file",
+			content: []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "malformed JSON",
+			content: []byte("{broken json"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "abcdef-result.json")
+			if err := os.WriteFile(tmpFile, tt.content, 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			parser := NewParser(tmpDir)
+			results, err := parser.Parse()
+			// Allure parser logs errors and continues, so check results are empty
+			if tt.wantErr {
+				if err != nil {
+					// This is fine - an error was returned
+					return
+				}
+				// Allure parser may not return error but should return empty results
+				if len(results) > 0 {
+					t.Errorf("parseFile() returned %d results for invalid input, want 0", len(results))
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseFile() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParser_Parse_FilenameWithSpaces(t *testing.T) {
+	tmpDir := t.TempDir()
+	spacedDir := filepath.Join(tmpDir, "dir with spaces")
+	if err := os.MkdirAll(spacedDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	jsonFile := filepath.Join(spacedDir, "abcdef-result.json")
+	content := []byte(`{"uuid":"abc","name":"T","start":1000,"stop":2000,"status":"passed","statusDetails":{},"steps":[],"attachments":[],"links":[],"labels":[]}`)
+	if err := os.WriteFile(jsonFile, content, 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	parser := NewParser(spacedDir)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() with spaces in path: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+}
+
 func TestParser_convertTest_SuiteField(t *testing.T) {
 	parser := &Parser{}
 

--- a/internal/parsers/junit/junit.go
+++ b/internal/parsers/junit/junit.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -84,11 +83,14 @@ func (p *Parser) parseFile(path string) ([]models.Result, error) {
 		err := xmlFile.Close()
 		if err != nil {
 			logger.Error("failed to close file", "error", err)
-			log.Println(err)
 		}
 	}()
 
-	byteValue, _ := io.ReadAll(xmlFile)
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		logger.Error("failed to read file", "error", err)
+		return nil, err
+	}
 
 	// Try to parse as TestSuites first (multiple test suites)
 	var testSuites TestSuites

--- a/internal/parsers/junit/junit.go
+++ b/internal/parsers/junit/junit.go
@@ -122,60 +122,15 @@ func convertTestSuites(testSuites TestSuites) []models.Result {
 	for _, testSuite := range testSuites.TestSuites {
 		for _, testCase := range testSuite.TestCases {
 			testCase := testCase
-			relation := models.Relation{
-				Suite: models.Suite{
-					Data: []models.SuiteData{},
-				},
-			}
-
-			if testSuites.Name != "" {
-				relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
-					Title: testSuites.Name,
-				})
-			}
-
-			parts := strings.Split(testSuite.Name, string(filepath.Separator))
-			if len(parts) > 1 {
-				for _, part := range parts {
-					relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
-						Title: part,
-					})
-				}
-			} else {
-				relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
-					Title: testSuite.Name,
-				})
-			}
-
+			relation := buildSuiteRelation(testSuites, testSuite)
 			signature := fmt.Sprintf("%s::%s::%s::%s", testSuites.Name, testSuite.Name, testCase.ClassName, testCase.Name)
-
-			status := "passed"
-			var stackTrace *string
-			var message *string
-
-			if testCase.Failure != nil {
-				status = "failed"
-				stackTrace = &testCase.Failure.Body
-				message = &testCase.Failure.Message
-			}
-
-			if testCase.Error != nil {
-				status = "invalid"
-				stackTrace = &testCase.Error.Body
-				message = &testCase.Error.Message
-			}
-
-			if testCase.Skipped != nil {
-				status = "skipped"
-				message = &testCase.Skipped.Message
-			}
+			status, stackTrace, message := resolveTestCaseStatus(testCase)
 
 			fields := make(map[string]string)
 			for k := range testCase.Properties.Property {
 				if isStepProperty(testCase.Properties.Property[k].Name) {
 					continue
 				}
-
 				fields[testCase.Properties.Property[k].Name] = testCase.Properties.Property[k].Value
 			}
 
@@ -190,7 +145,7 @@ func convertTestSuites(testSuites TestSuites) []models.Result {
 					Status:     status,
 					StackTrace: stackTrace,
 				},
-				Attachments: make([]models.Attachment, 0),
+				Attachments: buildSystemAttachments(testCase),
 				Steps:       steps,
 				StepType:    "text",
 				Params:      make(map[string]string),
@@ -199,33 +154,94 @@ func convertTestSuites(testSuites TestSuites) []models.Result {
 				Message:     message,
 			}
 
-			if testCase.SystemOut != "" {
-				c := []byte(testCase.SystemOut)
-				id := uuid.New()
-				result.Attachments = append(result.Attachments, models.Attachment{
-					ID:          &id,
-					Name:        "system-out.txt",
-					ContentType: "plain/text",
-					Content:     &c,
-				})
-			}
-
-			if testCase.SystemErr != "" {
-				c := []byte(testCase.SystemErr)
-				id := uuid.New()
-				result.Attachments = append(result.Attachments, models.Attachment{
-					ID:          &id,
-					Name:        "system-err.txt",
-					ContentType: "plain/text",
-					Content:     &c,
-				})
-			}
-
 			results = append(results, result)
 		}
 	}
 
 	return results
+}
+
+// buildSuiteRelation constructs the suite hierarchy relation for a test case
+func buildSuiteRelation(testSuites TestSuites, testSuite TestSuite) models.Relation {
+	relation := models.Relation{
+		Suite: models.Suite{
+			Data: []models.SuiteData{},
+		},
+	}
+
+	if testSuites.Name != "" {
+		relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
+			Title: testSuites.Name,
+		})
+	}
+
+	parts := strings.Split(testSuite.Name, string(filepath.Separator))
+	if len(parts) > 1 {
+		for _, part := range parts {
+			relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
+				Title: part,
+			})
+		}
+	} else {
+		relation.Suite.Data = append(relation.Suite.Data, models.SuiteData{
+			Title: testSuite.Name,
+		})
+	}
+
+	return relation
+}
+
+// resolveTestCaseStatus determines the status, stack trace, and message for a test case
+func resolveTestCaseStatus(testCase TestCase) (status string, stackTrace *string, message *string) {
+	status = "passed"
+
+	if testCase.Failure != nil {
+		status = "failed"
+		stackTrace = &testCase.Failure.Body
+		message = &testCase.Failure.Message
+	}
+
+	if testCase.Error != nil {
+		status = "invalid"
+		stackTrace = &testCase.Error.Body
+		message = &testCase.Error.Message
+	}
+
+	if testCase.Skipped != nil {
+		status = "skipped"
+		message = &testCase.Skipped.Message
+	}
+
+	return status, stackTrace, message
+}
+
+// buildSystemAttachments creates attachments for system-out and system-err
+func buildSystemAttachments(testCase TestCase) []models.Attachment {
+	attachments := make([]models.Attachment, 0)
+
+	if testCase.SystemOut != "" {
+		c := []byte(testCase.SystemOut)
+		id := uuid.New()
+		attachments = append(attachments, models.Attachment{
+			ID:          &id,
+			Name:        "system-out.txt",
+			ContentType: "plain/text",
+			Content:     &c,
+		})
+	}
+
+	if testCase.SystemErr != "" {
+		c := []byte(testCase.SystemErr)
+		id := uuid.New()
+		attachments = append(attachments, models.Attachment{
+			ID:          &id,
+			Name:        "system-err.txt",
+			ContentType: "plain/text",
+			Content:     &c,
+		})
+	}
+
+	return attachments
 }
 
 // parseSteps parses the steps from the properties

--- a/internal/parsers/junit/junit.go
+++ b/internal/parsers/junit/junit.go
@@ -1,6 +1,7 @@
 package junit
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -91,6 +92,8 @@ func (p *Parser) parseFile(path string) ([]models.Result, error) {
 		logger.Error("failed to read file", "error", err)
 		return nil, err
 	}
+
+	byteValue = bytes.TrimPrefix(byteValue, []byte("\xef\xbb\xbf"))
 
 	// Try to parse as TestSuites first (multiple test suites)
 	var testSuites TestSuites

--- a/internal/parsers/junit/junit_test.go
+++ b/internal/parsers/junit/junit_test.go
@@ -297,6 +297,30 @@ func stringPtr(v string) *string {
 	return &v
 }
 
+func TestParser_parseFile_ReadError(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "unreadable.xml")
+	err := os.WriteFile(tmpFile, []byte("<testsuites></testsuites>"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	// Make the file unreadable — os.Open (or io.ReadAll) fails on the file descriptor
+	err = os.Chmod(tmpFile, 0000)
+	if err != nil {
+		t.Fatalf("Failed to chmod test file: %v", err)
+	}
+
+	parser := NewParser(tmpFile)
+	result, err := parser.parseFile(tmpFile)
+
+	if err == nil {
+		t.Errorf("parseFile() expected error for unreadable file but got none")
+	}
+	if result != nil {
+		t.Errorf("parseFile() expected nil result for unreadable file, got %v", result)
+	}
+}
+
 func TestParser_Parse(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/parsers/junit/junit_test.go
+++ b/internal/parsers/junit/junit_test.go
@@ -321,6 +321,67 @@ func TestParser_parseFile_ReadError(t *testing.T) {
 	}
 }
 
+func TestParser_parseFile_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty file",
+			content: []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "malformed XML",
+			content: []byte("<testsuites><broken"),
+			wantErr: true,
+		},
+		{
+			name:    "UTF-8 BOM prefix with valid XML",
+			content: append([]byte("\xef\xbb\xbf"), []byte(`<testsuite name="S"><testcase name="T" time="0.1"/></testsuite>`)...),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.xml")
+			if err := os.WriteFile(tmpFile, tt.content, 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			parser := NewParser(tmpFile)
+			result, err := parser.parseFile(tmpFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(result) == 0 {
+				t.Error("parseFile() returned 0 results for valid input")
+			}
+		})
+	}
+}
+
+func TestParser_Parse_FilenameWithSpaces(t *testing.T) {
+	tmpDir := t.TempDir()
+	spacedDir := filepath.Join(tmpDir, "dir with spaces")
+	if err := os.MkdirAll(spacedDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	xmlFile := filepath.Join(spacedDir, "test file.xml")
+	if err := os.WriteFile(xmlFile, []byte(`<testsuite name="S"><testcase name="T" time="0.1"/></testsuite>`), 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	parser := NewParser(spacedDir)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() with spaces in path: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+}
+
 func TestParser_Parse(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/parsers/qase/qase.go
+++ b/internal/parsers/qase/qase.go
@@ -7,7 +7,6 @@ import (
 	models "github.com/qase-tms/qasectl/internal/models/result"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -127,7 +126,7 @@ func (p *Parser) convertAttachments(attachments []models.Attachment) []models.At
 		if os.IsNotExist(err) {
 			id := filepath.Base(*attachments[i].FilePath)
 			dir := filepath.Dir(p.path)
-			*attachments[i].FilePath = path.Join(dir, "attachments", id)
+			*attachments[i].FilePath = filepath.Join(dir, "attachments", id)
 		}
 	}
 

--- a/internal/parsers/qase/qase_test.go
+++ b/internal/parsers/qase/qase_test.go
@@ -37,6 +37,71 @@ func TestParseFile_WithBOM(t *testing.T) {
 	}
 }
 
+func TestParser_parseFile_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty file",
+			content: []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "malformed JSON",
+			content: []byte("{broken json"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.json")
+			if err := os.WriteFile(tmpFile, tt.content, 0644); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+			parser := NewParser(tmpFile)
+			results, err := parser.Parse()
+			if tt.wantErr {
+				// Qase parser logs errors and continues for dir-mode,
+				// but for single-file mode errors propagate through parseFile
+				if err != nil {
+					return
+				}
+				if len(results) > 0 {
+					t.Errorf("Parse() returned %d results for invalid input, want 0", len(results))
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Parse() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParser_Parse_FilenameWithSpaces(t *testing.T) {
+	tmpDir := t.TempDir()
+	spacedDir := filepath.Join(tmpDir, "dir with spaces")
+	if err := os.MkdirAll(spacedDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	jsonFile := filepath.Join(spacedDir, "test file.json")
+	content := []byte(`{"title":"T","execution":{"status":"passed","duration":100}}`)
+	if err := os.WriteFile(jsonFile, content, 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	parser := NewParser(spacedDir)
+	results, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parse() with spaces in path: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+}
+
 func TestParseFile_WithoutBOM(t *testing.T) {
 	content := []byte(`{
 		"title": "No BOM Test",

--- a/internal/parsers/xctest/xctest.go
+++ b/internal/parsers/xctest/xctest.go
@@ -338,53 +338,11 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 		logger := logger.With("testTitle", t.Name, "testIndex", i)
 		logger.Debug("processing test", "test", t)
 
-		suites := make([]models.SuiteData, 0)
-		suites = append(suites, models.SuiteData{Title: t.Metadata.Suite})
-		for _, s := range t.Suites {
-			suites = append(suites, models.SuiteData{
-				Title: s,
-			})
-		}
+		result := buildBaseResult(t)
+		setExecutionTimes(&result, t.Action.ActivitySummaries)
 
-		duration := t.Duration
-		result := models.Result{
-			Title:     t.Name,
-			Signature: &t.Signature,
-			Execution: models.Execution{
-				Status:    getStatus(t.Action.TestStatus.Value),
-				Duration:  &duration,
-			},
-			Fields:      map[string]string{},
-			Attachments: make([]models.Attachment, 0),
-			Params: map[string]string{
-				"Device":        t.Metadata.Device,
-				"Configuration": t.Metadata.Configuration,
-			},
-			Relations: models.Relation{
-				Suite: models.Suite{
-					Data: suites,
-				},
-			},
-			StepType: "text",
-			Muted:    false,
-		}
-
-		if len(t.Action.ActivitySummaries.Values) > 0 {
-			startTime := t.Action.ActivitySummaries.Values[0].Start.Value
-			endTime := t.Action.ActivitySummaries.Values[len(t.Action.ActivitySummaries.Values)-1].Finish.Value
-			startTimeFloat := float64(parseTime(startTime).UnixMilli())
-			endTimeFloat := float64(parseTime(endTime).UnixMilli())
-			result.Execution.StartTime = &startTimeFloat
-			result.Execution.EndTime = &endTimeFloat
-		}
-
-		if t.Action.FailureSummaries != nil {
-			var message string
-			for _, f := range t.Action.FailureSummaries.Values {
-				p.failures[f.UUID.Value] = f
-				message += f.Message.Value + "\n"
-			}
-			result.Execution.StackTrace = &message
+		if stackTrace := p.collectFailureSummaries(t.Action); stackTrace != nil {
+			result.Execution.StackTrace = stackTrace
 		} else {
 			logger.Debug("test has no failure summaries")
 		}
@@ -392,7 +350,6 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 		steps, _, a := p.getSteps(t.Action.ActivitySummaries, 0)
 		result.Attachments = append(result.Attachments, a...)
 
-		// Search for attachments in activitySummaries at test level
 		testLevelAttachments := p.getTestLevelAttachments(t.Action.ActivitySummaries)
 		result.Attachments = append(result.Attachments, testLevelAttachments...)
 
@@ -417,7 +374,6 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 						logger.Error("failed to get attachments", "error", err, "attachmentIndex", i)
 						continue
 					}
-
 					logger.Debug("successfully added failure attachment", "attachmentName", a.Name)
 					result.Attachments = append(result.Attachments, a)
 				}
@@ -432,6 +388,64 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 
 	logger.Debug("completed all tests processing", "totalResults", len(results))
 	return results
+}
+
+// buildBaseResult creates the initial Result from an XCTest entry
+func buildBaseResult(t XCTest) models.Result {
+	suites := make([]models.SuiteData, 0)
+	suites = append(suites, models.SuiteData{Title: t.Metadata.Suite})
+	for _, s := range t.Suites {
+		suites = append(suites, models.SuiteData{Title: s})
+	}
+
+	duration := t.Duration
+	return models.Result{
+		Title:     t.Name,
+		Signature: &t.Signature,
+		Execution: models.Execution{
+			Status:   getStatus(t.Action.TestStatus.Value),
+			Duration: &duration,
+		},
+		Fields:      map[string]string{},
+		Attachments: make([]models.Attachment, 0),
+		Params: map[string]string{
+			"Device":        t.Metadata.Device,
+			"Configuration": t.Metadata.Configuration,
+		},
+		Relations: models.Relation{
+			Suite: models.Suite{
+				Data: suites,
+			},
+		},
+		StepType: "text",
+		Muted:    false,
+	}
+}
+
+// setExecutionTimes sets start and end times from activity summaries
+func setExecutionTimes(result *models.Result, as ActivitySummaries) {
+	if len(as.Values) == 0 {
+		return
+	}
+	startTime := as.Values[0].Start.Value
+	endTime := as.Values[len(as.Values)-1].Finish.Value
+	startTimeFloat := float64(parseTime(startTime).UnixMilli())
+	endTimeFloat := float64(parseTime(endTime).UnixMilli())
+	result.Execution.StartTime = &startTimeFloat
+	result.Execution.EndTime = &endTimeFloat
+}
+
+// collectFailureSummaries extracts failure summaries and returns combined stack trace
+func (p *Parser) collectFailureSummaries(action ActionTestSummary) *string {
+	if action.FailureSummaries == nil {
+		return nil
+	}
+	var message string
+	for _, f := range action.FailureSummaries.Values {
+		p.failures[f.UUID.Value] = f
+		message += f.Message.Value + "\n"
+	}
+	return &message
 }
 
 func (p *Parser) isFailureProcessed(f string) bool {

--- a/internal/parsers/xctest/xctest.go
+++ b/internal/parsers/xctest/xctest.go
@@ -14,8 +14,11 @@ import (
 
 // Parser is a parser for XCTest files
 type Parser struct {
-	path  string
-	level stepLevel
+	path              string
+	level             stepLevel
+	caseId            *int64
+	failures          map[string]FailureSummary
+	processedFailures []string
 }
 
 // NewParser creates a new Parser
@@ -30,12 +33,7 @@ func NewParser(path, level string) (*Parser, error) {
 	}, nil
 }
 
-var (
-	layoutTime        = "2006-01-02T15:04:05.000-0700"
-	caseId            *int64
-	failures          map[string]FailureSummary
-	processedFailures []string
-)
+var layoutTime = "2006-01-02T15:04:05.000-0700"
 
 const (
 	internalStep   = "com.apple.dt.xctest.activity-type.internal"
@@ -322,9 +320,9 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 	var results []models.Result
 
 	for i, t := range tests {
-		caseId = nil
-		failures = make(map[string]FailureSummary)
-		processedFailures = make([]string, 0)
+		p.caseId = nil
+		p.failures = make(map[string]FailureSummary)
+		p.processedFailures = make([]string, 0)
 
 		logger := logger.With("testTitle", t.Name, "testIndex", i)
 		logger.Debug("processing test", "test", t)
@@ -372,7 +370,7 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 		if t.Action.FailureSummaries != nil {
 			var message string
 			for _, f := range t.Action.FailureSummaries.Values {
-				failures[f.UUID.Value] = f
+				p.failures[f.UUID.Value] = f
 				message += f.Message.Value + "\n"
 			}
 			result.Execution.StackTrace = &message
@@ -388,12 +386,12 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 		result.Attachments = append(result.Attachments, testLevelAttachments...)
 
 		result.Steps = steps
-		if caseId != nil {
-			result.TestOpsID = caseId
+		if p.caseId != nil {
+			result.TestOpsID = p.caseId
 		}
 
-		for k, v := range failures {
-			if isFailureProcessed(k) {
+		for k, v := range p.failures {
+			if p.isFailureProcessed(k) {
 				logger.Debug("skipping already processed failure", "failureId", k)
 				continue
 			}
@@ -425,9 +423,9 @@ func (p *Parser) getResults(tests []XCTest) []models.Result {
 	return results
 }
 
-func isFailureProcessed(f string) bool {
-	for _, p := range processedFailures {
-		if f == p {
+func (p *Parser) isFailureProcessed(f string) bool {
+	for _, proc := range p.processedFailures {
+		if f == proc {
 			return true
 		}
 	}
@@ -604,11 +602,11 @@ func (p *Parser) getSteps(as ActivitySummaries, level int) ([]models.Step, bool,
 			}
 
 			logger.Debug("successfully parsed Qase ID", "caseId", ID.ID)
-			if caseId == nil {
-				caseId = &ID.ID
-				logger.Debug("set case ID", "caseId", *caseId)
+			if p.caseId == nil {
+				p.caseId = &ID.ID
+				logger.Debug("set case ID", "caseId", *p.caseId)
 			} else {
-				logger.Debug("case ID already set", "existingCaseId", *caseId, "newCaseId", ID.ID)
+				logger.Debug("case ID already set", "existingCaseId", *p.caseId, "newCaseId", ID.ID)
 			}
 
 			continue
@@ -616,8 +614,8 @@ func (p *Parser) getSteps(as ActivitySummaries, level int) ([]models.Step, bool,
 
 		if v.FailureSummaryIDs != nil {
 			for _, f := range v.FailureSummaryIDs.Values {
-				if fm, ok := failures[f.Value]; ok {
-					processedFailures = append(processedFailures, f.Value)
+				if fm, ok := p.failures[f.Value]; ok {
+					p.processedFailures = append(p.processedFailures, f.Value)
 					isStepFailed = true
 					stepComment = fmt.Sprintf("Line: %s\n%s", fm.LineNumber.Value, fm.Message.Value)
 					if fm.Attachments != nil {

--- a/internal/parsers/xctest/xctest.go
+++ b/internal/parsers/xctest/xctest.go
@@ -43,6 +43,17 @@ const (
 	heicExt        = ".heic"
 )
 
+// heicSignatures contains all known HEIC/HEIF ftyp box identifiers
+var heicSignatures = []string{
+	"ftypheic",
+	"ftypheix",
+	"ftypheis",
+	"ftyphevc",
+	"ftyphevx",
+	"ftyphevs",
+	"ftyphevm",
+}
+
 // Parse parses the XCTest file and returns the results
 func (p *Parser) Parse() ([]models.Result, error) {
 	const op = "xctest.Parser.Parse"
@@ -445,7 +456,7 @@ func (p *Parser) detectFileExtension(data []byte) string {
 		return ".png"
 	case len(data) >= 2 && string(data[0:2]) == "\xff\xd8":
 		return ".jpg"
-	case len(data) >= 6 && string(data[0:6]) == "GIF87a" || string(data[0:6]) == "GIF89a":
+	case len(data) >= 6 && (string(data[0:6]) == "GIF87a" || string(data[0:6]) == "GIF89a"):
 		return ".gif"
 	case len(data) >= 4 && string(data[0:4]) == "RIFF" && len(data) >= 8 && string(data[8:12]) == "WEBP":
 		return ".webp"
@@ -459,35 +470,20 @@ func (p *Parser) detectFileExtension(data []byte) string {
 		return ".tiff"
 	case len(data) >= 4 && string(data[0:4]) == "MM\x00*":
 		return ".tiff"
+	}
+
 	// Check for HEIC/HEIF
-	case len(data) >= 12 && string(data[4:12]) == "ftypheic":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftypheix":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftypheis":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevc":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevx":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevs":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevm":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftypheis":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftypheix":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftypheic":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevc":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevx":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevs":
-		return ".heic"
-	case len(data) >= 12 && string(data[4:12]) == "ftyphevm":
-		return ".heic"
+	if len(data) >= 12 {
+		ftyp := string(data[4:12])
+		for _, sig := range heicSignatures {
+			if ftyp == sig {
+				return ".heic"
+			}
+		}
+	}
+
+	// Check for other formats
+	switch {
 	// Check for PDF
 	case len(data) >= 4 && string(data[0:4]) == "%PDF":
 		return ".pdf"

--- a/internal/parsers/xctest/xctest_test.go
+++ b/internal/parsers/xctest/xctest_test.go
@@ -74,6 +74,26 @@ func TestParser_IsFailureProcessed(t *testing.T) {
 	}
 }
 
+func TestNewParser_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "non-xcresult extension", path: "test.xml", wantErr: true},
+		{name: "empty string path", path: "", wantErr: true},
+		{name: "valid xcresult extension", path: "test.xcresult", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewParser(tt.path, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewParser(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // makeHeicData creates a minimal byte slice with the given ftyp signature at bytes 4-12
 func makeHeicData(ftyp string) []byte {
 	data := make([]byte, 16)

--- a/internal/parsers/xctest/xctest_test.go
+++ b/internal/parsers/xctest/xctest_test.go
@@ -1,0 +1,75 @@
+package xctest
+
+import (
+	"testing"
+)
+
+// TestParser_InstanceIsolation verifies that Parser struct fields
+// are instance-scoped, not shared across instances.
+func TestParser_InstanceIsolation(t *testing.T) {
+	// Create two parser instances (use invalid paths — we won't call Parse)
+	p1, err := NewParser("test1.xcresult", "")
+	if err != nil {
+		t.Fatalf("Failed to create parser 1: %v", err)
+	}
+	p2, err := NewParser("test2.xcresult", "")
+	if err != nil {
+		t.Fatalf("Failed to create parser 2: %v", err)
+	}
+
+	// Initialize fields on p1
+	var id1 int64 = 42
+	p1.caseId = &id1
+	p1.failures = map[string]FailureSummary{"key1": {}}
+	p1.processedFailures = []string{"f1"}
+
+	// Initialize fields on p2
+	var id2 int64 = 99
+	p2.caseId = &id2
+	p2.failures = map[string]FailureSummary{"key2": {}}
+	p2.processedFailures = []string{"f2"}
+
+	// Verify p1 fields are not affected by p2
+	if *p1.caseId != 42 {
+		t.Errorf("p1.caseId = %d, want 42", *p1.caseId)
+	}
+	if _, ok := p1.failures["key1"]; !ok {
+		t.Error("p1.failures missing key1")
+	}
+	if _, ok := p1.failures["key2"]; ok {
+		t.Error("p1.failures unexpectedly has key2 from p2")
+	}
+	if len(p1.processedFailures) != 1 || p1.processedFailures[0] != "f1" {
+		t.Errorf("p1.processedFailures = %v, want [f1]", p1.processedFailures)
+	}
+
+	// Verify p2 fields are not affected by p1
+	if *p2.caseId != 99 {
+		t.Errorf("p2.caseId = %d, want 99", *p2.caseId)
+	}
+	if _, ok := p2.failures["key2"]; !ok {
+		t.Error("p2.failures missing key2")
+	}
+	if _, ok := p2.failures["key1"]; ok {
+		t.Error("p2.failures unexpectedly has key1 from p1")
+	}
+}
+
+// TestParser_IsFailureProcessed verifies the method works on instance state
+func TestParser_IsFailureProcessed(t *testing.T) {
+	p, err := NewParser("test.xcresult", "")
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+	p.processedFailures = []string{"abc", "def"}
+
+	if !p.isFailureProcessed("abc") {
+		t.Error("isFailureProcessed(abc) = false, want true")
+	}
+	if !p.isFailureProcessed("def") {
+		t.Error("isFailureProcessed(def) = false, want true")
+	}
+	if p.isFailureProcessed("ghi") {
+		t.Error("isFailureProcessed(ghi) = true, want false")
+	}
+}

--- a/internal/parsers/xctest/xctest_test.go
+++ b/internal/parsers/xctest/xctest_test.go
@@ -73,3 +73,73 @@ func TestParser_IsFailureProcessed(t *testing.T) {
 		t.Error("isFailureProcessed(ghi) = true, want false")
 	}
 }
+
+// makeHeicData creates a minimal byte slice with the given ftyp signature at bytes 4-12
+func makeHeicData(ftyp string) []byte {
+	data := make([]byte, 16)
+	// bytes 0-3: arbitrary (file size in real HEIC)
+	data[0], data[1], data[2], data[3] = 0x00, 0x00, 0x00, 0x18
+	copy(data[4:12], ftyp)
+	return data
+}
+
+func TestParser_detectFileExtension(t *testing.T) {
+	p, err := NewParser("test.xcresult", "")
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected string
+	}{
+		{
+			name:     "PNG signature",
+			data:     []byte("\x89PNG\r\n\x1a\n" + "extra"),
+			expected: ".png",
+		},
+		{
+			name:     "JPG signature",
+			data:     []byte("\xff\xd8\xff\xe0"),
+			expected: ".jpg",
+		},
+		// All 7 HEIC ftyp signatures
+		{name: "HEIC ftypheic", data: makeHeicData("ftypheic"), expected: ".heic"},
+		{name: "HEIC ftypheix", data: makeHeicData("ftypheix"), expected: ".heic"},
+		{name: "HEIC ftypheis", data: makeHeicData("ftypheis"), expected: ".heic"},
+		{name: "HEIC ftyphevc", data: makeHeicData("ftyphevc"), expected: ".heic"},
+		{name: "HEIC ftyphevx", data: makeHeicData("ftyphevx"), expected: ".heic"},
+		{name: "HEIC ftyphevs", data: makeHeicData("ftyphevs"), expected: ".heic"},
+		{name: "HEIC ftyphevm", data: makeHeicData("ftyphevm"), expected: ".heic"},
+		{
+			name:     "PDF signature",
+			data:     []byte("%PDF-1.4"),
+			expected: ".pdf",
+		},
+		{
+			name:     "JSON object",
+			data:     []byte(`{"key": "value"}`),
+			expected: ".json",
+		},
+		{
+			name:     "unknown bytes",
+			data:     []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D},
+			expected: "",
+		},
+		{
+			name:     "too short",
+			data:     []byte{0x01, 0x02},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.detectFileExtension(tt.data)
+			if got != tt.expected {
+				t.Errorf("detectFileExtension() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -61,76 +61,19 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 		return fmt.Errorf("no results to upload")
 	}
 
-	for i := range results {
-		if len([]rune(results[i].Title)) > 255 {
-			logger.Warn("result title is too long and will be truncated", "title", results[i].Title)
-			runes := []rune(results[i].Title)
-			results[i].Title = string(runes[:255])
-		}
-	}
+	truncateTitles(results)
 
-	runID := p.RunID
-	isTestRunCreated := false
-	if runID == 0 {
-		// Find the earliest StartTime from all results
-		var startTime *int64
-		if minStartTime := s.findMinStartTime(results); minStartTime != nil {
-			// Subtract 10 seconds (10000 milliseconds) from the earliest start time
-			runStartTime := int64(*minStartTime) - 10000
-			startTime = &runStartTime
-			logger.Debug("calculated run start time", "startTime", runStartTime, "minResultStartTime", *minStartTime)
-		}
-
-		ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0, []string{}, false, "", startTime)
-		if err != nil {
-			return err
-		}
-		runID = ID
-		isTestRunCreated = true
-	} else {
-		sort.Slice(results, func(i, j int) bool {
-			if results[i].Execution.StartTime == nil {
-				return false
-			}
-			if results[j].Execution.StartTime == nil {
-				return true
-			}
-			return *results[i].Execution.StartTime < *results[j].Execution.StartTime
-		})
-
-		for i := range results {
-			results[i].Execution.StartTime = nil
-			results[i].Execution.EndTime = nil
-		}
+	runID, isTestRunCreated, results, err := s.prepareRun(ctx, p, results)
+	if err != nil {
+		return err
 	}
 
 	if p.Suite != "" {
-		s := []models.SuiteData{
-			{Title: p.Suite,
-				PublicID: nil,
-			},
-		}
-
-		for i := range results {
-			results[i].Relations.Suite.Data = append(s, results[i].Relations.Suite.Data...)
-		}
+		prependSuite(p.Suite, results)
 	}
 
-	if len(p.Statuses) > 0 {
-		for i := range results {
-			if status, ok := p.Statuses[results[i].Execution.Status]; ok {
-				results[i].Execution.Status = status
-			}
-		}
-	}
+	applyResultTransforms(p, results)
 
-	if p.SkipParams {
-		for i := range results {
-			results[i].Params = nil
-		}
-	}
-
-	// Filter attachments if extensions are specified
 	if p.AttachmentExtensions != "" {
 		results = s.filterAttachments(results, p.AttachmentExtensions)
 	}
@@ -148,6 +91,77 @@ func (s *Service) Upload(ctx context.Context, p UploadParams) error {
 	}
 
 	return nil
+}
+
+// truncateTitles truncates result titles longer than 255 runes
+func truncateTitles(results []models.Result) {
+	for i := range results {
+		if len([]rune(results[i].Title)) > 255 {
+			slog.Warn("result title is too long and will be truncated", "title", results[i].Title)
+			runes := []rune(results[i].Title)
+			results[i].Title = string(runes[:255])
+		}
+	}
+}
+
+// prepareRun creates a run if needed and sorts results for existing runs
+func (s *Service) prepareRun(ctx context.Context, p UploadParams, results []models.Result) (int64, bool, []models.Result, error) {
+	if p.RunID != 0 {
+		sort.Slice(results, func(i, j int) bool {
+			if results[i].Execution.StartTime == nil {
+				return false
+			}
+			if results[j].Execution.StartTime == nil {
+				return true
+			}
+			return *results[i].Execution.StartTime < *results[j].Execution.StartTime
+		})
+		for i := range results {
+			results[i].Execution.StartTime = nil
+			results[i].Execution.EndTime = nil
+		}
+		return p.RunID, false, results, nil
+	}
+
+	var startTime *int64
+	if minStartTime := s.findMinStartTime(results); minStartTime != nil {
+		runStartTime := int64(*minStartTime) - 10000
+		startTime = &runStartTime
+		slog.Debug("calculated run start time", "startTime", runStartTime, "minResultStartTime", *minStartTime)
+	}
+
+	ID, err := s.rs.CreateRun(ctx, p.Project, p.Title, p.Description, "", 0, 0, []string{}, false, "", startTime)
+	if err != nil {
+		return 0, false, nil, err
+	}
+	return ID, true, results, nil
+}
+
+// prependSuite prepends the given suite name to all result relations
+func prependSuite(suite string, results []models.Result) {
+	s := []models.SuiteData{
+		{Title: suite, PublicID: nil},
+	}
+	for i := range results {
+		results[i].Relations.Suite.Data = append(s, results[i].Relations.Suite.Data...)
+	}
+}
+
+// applyResultTransforms applies status mapping and parameter skipping
+func applyResultTransforms(p UploadParams, results []models.Result) {
+	if len(p.Statuses) > 0 {
+		for i := range results {
+			if status, ok := p.Statuses[results[i].Execution.Status]; ok {
+				results[i].Execution.Status = status
+			}
+		}
+	}
+
+	if p.SkipParams {
+		for i := range results {
+			results[i].Params = nil
+		}
+	}
 }
 
 func (s *Service) uploadResults(ctx context.Context, project string, batchSize, runID int64, results []models.Result) error {

--- a/internal/service/result/result.go
+++ b/internal/service/result/result.go
@@ -178,12 +178,12 @@ func (s *Service) uploadResults(ctx context.Context, project string, batchSize, 
 
 	g, ctx := errgroup.WithContext(ctx)
 
-	batchCh := make(chan []models.Result)
-
 	workerCount := runtime.NumCPU()
 	if workerCount > MaxWorkerCount {
 		workerCount = MaxWorkerCount
 	}
+
+	batchCh := make(chan []models.Result, workerCount)
 
 	for i := 0; i < workerCount; i++ {
 		g.Go(func() error {

--- a/internal/service/result/result_test.go
+++ b/internal/service/result/result_test.go
@@ -927,7 +927,7 @@ func TestService_Upload(t *testing.T) {
 					f.client.EXPECT().
 						UploadData(gomock.Any(), tt.args.p.Project, gomock.Any(), gomock.Any()).
 						Return(tt.args.err).
-						Times(1)
+						MinTimes(1)
 				} else if tt.name == "sort results by StartTime and remove time when RunID is set" {
 					// Verify sorting and time removal
 					f.client.EXPECT().


### PR DESCRIPTION
## Summary

Milestone v1.1 "Quality & Safety" — eliminates critical bugs, removes duplication, adds test coverage, and optimizes batch throughput.

### Phase 1: Bug Fixes & Safety
- Propagate `io.ReadAll` error in JUnit parser instead of silently proceeding with empty bytes
- Move XCTest parser globals (`caseId`, `failures`, `processedFailures`) to struct fields for concurrency safety
- Replace `fmt.Println(err)` with `slog.Error` in all cmd files
- Close file descriptor via `defer` in `convertAttachments` to prevent leaks
- Replace `path.Join` with `filepath.Join` in qase parser for correct OS path handling

### Phase 2: Code Quality
- Extract generic `paginate[T]` helper — 4 duplicated pagination call sites now delegate to one function
- Replace 14 duplicated HEIC signature detection `case` blocks with a signature array loop
- Decompose `Upload()`, `convertTestSuites()`, and `getResults()` into focused ~30-line helper functions

### Phase 3: Tests & Performance
- Add 5 integration tests for cmd layer (root command, verbose flag, subcommand registration, flags)
- Add edge-case tests for all 4 parsers (empty files, malformed XML/JSON, BOM prefix, filenames with spaces)
- Add UTF-8 BOM stripping to JUnit parser for consistency with allure/qase
- Buffer batch channel in `uploadResults` with capacity = `workerCount` for non-blocking producer
- Make pagination limit configurable via `QASE_TESTOPS_PAGINATION_LIMIT` env var (default 50 preserved)

## Test plan
- [ ] `go test ./...` passes
- [ ] Verify JUnit parser returns error on `io.ReadAll` failure
- [ ] Verify XCTest parser instances don't share state
- [ ] Verify `QASE_TESTOPS_PAGINATION_LIMIT` env var changes page size
- [ ] Verify batch upload doesn't block when all workers are busy