### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Qase CLI is available for both **Qase** and **Qase Enterprise** users.
 
 ## Installation
 
+### Install via Homebrew (macOS/Linux)
+
+```bash
+brew tap qase-tms/tap
+brew install qasectl
+```
+
 ### Install via `go install`
 
 The easiest way to install Qase CLI is using `go install`:


### PR DESCRIPTION
## Summary
- Add Homebrew installation section to README as the first installation method
- Users can now install qasectl via `brew tap qase-tms/tap && brew install qasectl`

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the Homebrew tap and formula exist and work: `brew tap qase-tms/tap && brew install qasectl`